### PR TITLE
Add Floorplan

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -62,6 +62,7 @@ automation old: !include_dir_merge_list automation
 camera: !include_dir_merge_list camera
 device_tracker: !include_dir_merge_list device_tracker
 media_player: !include_dir_merge_list media_player
+panel_custom: !include_dir_merge_list panel_custom
 # scene: !include_dir_merge_list scene
 sensor: !include_dir_merge_list sensor
 switch: !include_dir_merge_list switch

--- a/customize/device_tracker.yaml
+++ b/customize/device_tracker.yaml
@@ -20,6 +20,9 @@ device_tracker.echo_dot_family_room:
 device_tracker.echo_dot_living_room:
   hidden: true
 
+device_tracker.echo_dot_living_room:
+  hidden: true
+
 device_tracker.ecobee:
   hidden: true
 

--- a/floorplan.yaml
+++ b/floorplan.yaml
@@ -1,0 +1,315 @@
+name: Floorplan
+image: /local/custom_ui/floorplan/floorplan.svg
+stylesheet: /local/custom_ui/floorplan/floorplan.css
+
+# These options are optional
+warnings:                  # enable warnings (to find out why things might ot be working correctly)
+# pan_zoom:                  # enable experimental panning / zooming
+# hide_app_toolbar:          # hide the application toolbar (when used as a custom panel)
+# date_format: DD-MMM-YYYY   # Date format to use in hover-over text
+
+last_motion_entity: sensor.template_last_motion
+last_motion_class: last-motion
+
+groups:
+  - name: Button Toggle Floor
+    elements:
+      - button_toggle_floor
+    action:
+      domain: class
+      service: toggle
+      data:
+        elements:
+          - main
+        classes:
+          - layer-visible
+          - layer-hidden
+        default_class: layer-visible
+
+  # - name: Date
+  #   entities:
+  #     - sensor.floorplan_date
+  #   text_template: '${entity.state ? entity.state : "undefined"}'
+  #   class_template: 'return "static-text";'
+
+  # - name: Time
+  #   entities:
+  #     - sensor.floorplan_time
+  #   text_template: '${entity.state ? entity.state : "undefined"}'
+  #   class_template: 'return "static-text";'
+
+  # - name: Weather Icon
+  #   entities:
+  #     - sensor.weather_icon
+  #   image_template: '
+  #     var imageName = "";
+  #     switch (entity.state) {
+  #       case "clear-day":
+  #         imageName = "day";
+  #         break;
+  #       case "clear-night":
+  #         imageName = "night";
+  #         break;
+  #       case "partly-cloudy-day":
+  #         imageName = "cloudy-day-1";
+  #         break;
+  #       case "partly-cloudy-night":
+  #         imageName = "cloudy-night-1";
+  #         break;
+  #       case "cloudy":
+  #         imageName = "cloudy";
+  #         break;
+  #       case "rain":
+  #         imageName = "rainy-1";
+  #         break;
+  #       case "snow":
+  #         imageName = "snowy-1";
+  #         break;
+  #     }
+  #     return "/local/custom_ui/floorplan/images/weather/" + imageName + ".svg";
+  #     '
+
+  # - name: Weather
+  #   entities:
+  #     - sensor.weather_temperature
+  #   text_template: '${entity.state ? Math.ceil(entity.state) : "undefined"}'
+  #   class_template: '
+  #     if (entity.state < 40)
+  #       return "temp-low";
+  #     else if (entity.state < 80)
+  #       return "temp-medium";
+  #     else if (entity.state < 80)
+  #       return "temp-medium";
+  #     else
+  #       return "temp-high";
+  #     '
+
+  - name: Lights
+    entities:
+      - light.kitchen_level
+      - switch.dining_room_light_switch
+      - light.living_room_level
+      - switch.front_entry_light_switch
+      - switch.garage_entry_light_switch
+      - switch.garage_light_switch
+      # - light.lamp1_level
+      # - light.lamp2_level
+      - switch.hallway_light_switch
+      - switch.basement_hallway_light_switch
+      # - light.family_room_level
+      # - light.vr_space_level
+      # - light.theater_room_level
+      # - light.theater_walls_level
+      # - light.bedroom_master_level
+      # - switch.bedroom1_light_switch
+      # - switch.bedroom2_light_switch
+      # - switch.bedroom3_light_switch
+      # - switch.bedroom4_light_switch
+      - switch.outside_front_light_switch
+      - switch.outside_side_light_switch
+      - switch.outside_back_light_switch
+    states:
+      - state: 'on'
+        class: 'light-on'
+      - state: 'off'
+        class: 'light-off'
+    action:
+      domain: homeassistant
+      service: toggle
+
+  - name: Doors
+    entities:
+      - sensor.door_back
+      # - sensor.door_laundry
+      # - sensor.door_bathroom_m
+      # - sensor.door_bedroom_m_closet
+      # - sensor.door_bedroom_m
+      # - sensor.door_bathroom_1
+      # - sensor.door_bathroom_1_closet
+      # - sensor.door_bedroom_1
+      # - sensor.door_bedroom_2
+      # - sensor.door_pantry
+      # - sensor.door_entry_closet
+      - sensor.door_front
+      - sensor.door_garage_entry
+      - sensor.door_garage_outside
+    states:
+      - state: 'Closed'
+        class: 'closed'
+      - state: 'Open'
+        class: 'open'
+
+  - name: Covers
+    entities:
+      - sensor.garage_door_status
+    states:
+      - state: 'Unknown'
+        class: 'closed'
+      - state: 'Offline'
+        class: 'closed'
+      - state: 'Closed'
+        class: 'closed'
+      - state: 'Closing'
+        class: 'open'
+      - state: 'Open'
+        class: 'open'
+      - state: 'Opening'
+        class: 'closed'
+
+  # - name: Windows
+  #   entities:
+  #     - sensor.window_bedroom_m
+  #     - sensor.window_bathroom_m
+  #     - sensor.window_living_room_1
+  #     - sensor.window_living_room_2
+  #     - sensor.window_dining_room_1
+  #     - sensor.window_dining_room_2
+  #     - sensor.window_kitchen
+  #     - sensor.window_bedroom_1
+  #     - sensor.window_bedroom_2
+  #     - sensor.window_garage
+  #     - sensor.window_family_room_1
+  #     - sensor.window_family_room_2
+  #     - sensor.window_bedroom_3
+  #     - sensor.window_bedroom_4
+  #   states:
+  #     - state: 'Closed'
+  #       class: 'window-closed'
+  #     - state: 'Open'
+  #       class: 'window-open'
+
+  # - name: Motion
+  #   entities:
+  #     - sensor.motion_kitchen
+  #     - sensor.occupancy_home
+  #     - sensor.occupancy_office
+  #   states:
+  #     - state: 'off'
+  #       class: 'room-no-motion'
+  #     - state: 'on'
+  #       class: 'room-motion'
+
+  - name: Devices
+    entities:
+      - sensor.device_athos
+      - sensor.device_erebus
+      - sensor.device_echo_dot_living_room
+      # - sensor.device_echo_dot_family_room
+      - sensor.device_sony_tv
+      - sensor.device_nasya
+      - sensor.device_rmjclarkmbpr15
+    states:
+      - state: 'Offline'
+        class: 'device-off'
+      - state: 'Online'
+        class: 'device-on'
+
+  - name: Media Players
+    entities:
+      # - media_player.plex_shield_bedroom
+      - media_player.plex_shield_living_room
+      # - media_player.plex_rasplex
+      # - media_player.mechanixcast
+      - media_player.yamaha_receiver
+    states:
+      - state: 'off'
+        class: 'mediaplayer-off'
+      - state: 'idle'
+        class: 'mediaplayer-idle'
+      - state: 'paused'
+        class: 'mediaplayer-paused'
+      - state: 'playing'
+        class: 'mediaplayer-playing'
+      - state: 'on'
+        class: 'mediaplayer-on'
+
+  # - name: Temperature
+  #   entities:
+  #     - sensor.home_temperature
+  #     - sensor.kitchen_motion_temperature
+  #     - sensor.office_temperature
+  #   text_template: '${entity.state ? entity.state + "°C" : "undefined"}'
+  #   class_template: '
+  #     var temp = parseFloat(entity.state.replace("°", ""));
+  #     if (temp < 62)
+  #       return "temp-very-low-background";
+  #     else if (temp < 70)
+  #       return "temp-below-average-background";
+  #     else if (temp < 74)
+  #       return "temp-average-background";
+  #     else
+  #       return "temp-very-high-background";
+  #     '
+
+#   - name: Switches
+#     entities:
+#       - switch.doorbell
+#     states:
+#       - state: 'on'
+#         class: 'doorbell-on'
+#       - state: 'off'
+#         class: 'doorbell-off'
+
+#   - name: NVR
+#     entities:
+#       - binary_sensor.blue_iris_nvr
+#     text_template: '${(entity.state === "on") ? "online" : "offline"}'
+#     states:
+#       - state: 'off'
+#         class: 'danger-text'
+#       - state: 'on'
+#         class: 'success-text'
+
+#   - name: Alarm Panel
+#     entities:
+#       - alarm_control_panel.alarm
+#     states:
+#       - state: 'armed_away'
+#         class: 'alarm-armed'
+#       - state: 'armed_home'
+#         class: 'alarm-armed'
+#       - state: 'disarmed'
+#         class: 'alarm-disarmed'
+
+#   - name: Binary Sensors
+#     entities:
+#       - sensor.motion_kitchen
+#       - sensor.occupancy_home
+#       - sensor.occupancy_office
+#     states:
+#       - state: 'off'
+#         class: 'info-background'
+#       - state: 'on'
+#         class: 'warning-background'
+#     state_transitions:
+#       - name: On to off
+#         from_state: 'on'
+#         to_state: 'off'
+#         duration: 10
+
+#   - name: Cameras
+#     entities:
+#       - camera.hallway
+#       - camera.driveway
+#       - camera.front_door
+#       - camera.backyard
+#     states:
+#       - state: 'idle'
+#         class: 'camera-idle'
+
+#   - name: thermostat_temp
+#     entities:
+#       - climate.downstairs
+#       - climate.upstairs
+#     text_template: '${entity.attributes.current_temperature ? entity.attributes.current_temperature : "undefined"}'
+#
+# The above text_template uses extended attributes from the climate.* objects to get current temperature.
+
+#   - name: text_states
+#     entities:
+#       - sensor.downstairs_thermostat_humidity
+#       - sensor.dark_sky_temperature
+#       - sensor.last_message
+#     text_template: '${entity.state ? entity.state.replace(/\s{2,}/g,"") : "undefined"}'
+#
+# The above text_template uses jQuery syntax to search and replace any instance of 2 consecutive (or more) spaces in a string of text.

--- a/panel_custom/floorplan.yaml
+++ b/panel_custom/floorplan.yaml
@@ -1,0 +1,9 @@
+###########################################################
+# Panel Custom: Floorplan
+###########################################################
+
+- name: floorplan
+  sidebar_title: Floorplan
+  sidebar_icon: mdi:floor-plan
+  url_path: floorplan
+  config: !include ../floorplan.yaml

--- a/panels/floorplan.html
+++ b/panels/floorplan.html
@@ -1,0 +1,74 @@
+<link rel="import" href="/local/custom_ui/floorplan/ha-floorplan.html" async>
+
+<dom-module id="ha-panel-floorplan">
+
+  <template>
+    <style include="ha-style">
+      .container-fullscreen {
+        height: calc(100%);
+        vertical-align: top;
+        position: relative;
+      }
+
+      .container-with-toolbar {
+        height: calc(100% - 64px);
+        vertical-align: top;
+        position: relative;
+      }
+
+      [hidden] {
+        display: none !important;
+      }
+    </style>
+
+    <app-toolbar hidden$='{{!showAppToolbar}}'>
+      <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
+      <div main-title>[[panel.title]]</div>
+    </app-toolbar>
+
+    <div class$='[[containerClass]]'>
+      <ha-floorplan hass=[[hass]] config=[[panel.config]] is-panel></ha-floorplan>
+    </div>
+  </template>
+
+</dom-module>
+
+<script>
+  Polymer({
+    is: 'ha-panel-floorplan',
+
+    properties: {
+      hass: {
+        type: Object,
+      },
+      narrow: {
+        type: Boolean,
+        value: false,
+      },
+      showMenu: {
+        type: Boolean,
+        value: true,
+      },
+      showAppToolbar: {
+        type: Boolean,
+        value: false,
+      },
+      panel: {
+        type: Object,
+        observer: 'panelChanged',
+      },
+      containerClass: {
+        type: String,
+        value: 'container-fullscreen',
+      }
+    },
+
+    panelChanged: function() {
+      var hideAppToolbar = ((this.panel.config.hide_app_toolbar === null) || (this.panel.config.hide_app_toolbar !== undefined));
+      this.showAppToolbar = !hideAppToolbar;
+      this.containerClass = this.showAppToolbar ? 'container-with-toolbar' : 'container-fullscreen';
+    },
+
+  });
+
+</script>

--- a/www/custom_ui/floorplan/floorplan.css
+++ b/www/custom_ui/floorplan/floorplan.css
@@ -1,0 +1,326 @@
+/**
+ * Animations
+ */
+
+/* Door open clockwise */
+@keyframes doorOpen {
+  100% { transform: rotate(90deg); }
+}
+@keyframes doorClose {
+  0% { transform: rotate(90deg); }
+  100% { transform: none; }
+}
+
+/* Door open counter-clockwise */
+@keyframes doorOpenCCW {
+  100% { transform: rotate(-90deg); }
+}
+@keyframes doorCloseCCW {
+  0% { transform: rotate(-90deg); }
+  100% { transform: none; }
+}
+
+/* Door Angled open clockwise */
+@keyframes doorOpenDownRight {
+  100% { transform: rotate(45deg); }
+}
+@keyframes doorCloseDownRight {
+  0% { transform: rotate(45deg); }
+  100% { transform: rotate(-45deg); }
+}
+
+/* Door Angled open counter-clockwise */
+@keyframes doorOpenDownLeft {
+  100% { transform: rotate(-45deg); }
+}
+@keyframes doorCloseDownLeft {
+  0% { transform: rotate(-45deg); }
+  100% { transform: rotate(45deg); }
+}
+}
+
+/* Door slide open left */
+@keyframes slideLeft {
+  0% { transform: translateX(100%); }
+  100% { transform: none; }
+}
+@keyframes slideRight {
+  100% { transform: translateX(100%); }
+}
+
+/* Door slide open up */
+@keyframes slideUp {
+  0% { transform: translateY(0%); }
+  100% { transform: translateY(-100%); }
+}
+@keyframes slideDown {
+  0% { transform: translateY(-100%); }
+  100% { transform: none; }
+}
+
+/* Fade */
+@keyframes fadeIn {
+  0% { opacity: 0; display: none; }
+  100% { opacity: 1; }
+}
+
+@keyframes fadeOut {
+  100% { opacity: 0; display: none; }
+  0% { opacity: 1; }
+}
+
+/* SVG shapes */
+
+svg, svg * {
+  vector-effect: non-scaling-stroke !important;
+  pointer-events: all !important;
+}
+
+.ha-entity {
+  transition: fill 2s ease, stroke 2s ease;
+}
+
+/* Hover */
+
+.ha-entity:hover {
+  stroke: #03a9f4 !important;
+  stroke-width: 1 !important;
+  stroke-opacity: 1 !important;
+  paint-order:markers stroke fill !important;
+}
+
+/* Static Text */
+
+.static-text {
+  font-family : Helvetica;
+  font-weight : bold;
+  fill: #ffffa6;
+}
+
+/* Bootstrap success */
+
+.success-text {
+  fill: #3c763d !important;
+}
+
+.success-background, .success-text-background {
+  fill: #dff0d8 !important;
+  fill-opacity: 1 !important;
+  stroke: #d6e9c6 !important;
+  stroke-width: 1px !important;
+}
+
+/* Bootstrap info */
+
+.info-text {
+  fill: #31708f !important;
+}
+
+.info-background, .info-text-background {
+  fill: #d9edf7 !important;
+  fill-opacity: 1 !important;
+  stroke: #bce8f1 !important;
+  stroke-width: 1px !important;
+}
+
+/* Bootstrap warning */
+
+.warning-text {
+  fill: #8a6d3b !important;
+}
+
+.warning-background, .warning-text-background  {
+  fill: #fcf8e3 !important;
+  fill-opacity: 1 !important;
+  stroke: #faebcc !important;
+  stroke-width: 1px !important;
+}
+
+/* Bootstrap danger */
+
+.danger-text {
+  fill: #a94442 !important;
+}
+
+.danger-background, .danger-text-background {
+  fill: #f2dede !important;
+  fill-opacity: 1 !important;
+  stroke: #ebccd1 !important;
+  stroke-width: 1px !important;
+}
+
+/* Visibility */
+
+.layer-visible {
+  animation-duration: 0.3s;
+  animation-name: fadeIn;
+  animation-fill-mode: forwards;
+}
+
+.layer-hidden {
+  animation-duration: 0.3s;
+  animation-name: fadeOut;
+  animation-fill-mode: forwards;
+}
+
+/* Last motion entity */
+
+.last-motion {
+  stroke: #808080 !important;
+  stroke-width: 1px !important;
+  stroke-opacity: 1 !important;
+}
+
+
+/* Origin points /*
+/* Set as a class in SVG in many cases */
+
+.origin-tl {
+  transform-origin: top left;
+}
+.origin-tr {
+  transform-origin: top right;
+}
+.origin-bl {
+  transform-origin: bottom left;
+}
+.origin-br {
+  transform-origin: bottom right;
+}
+
+/* Motion */
+
+.room-no-motion {
+  fill-opacity: 0 !important;
+}
+
+.room-motion {
+  fill-opacity: 1 !important;
+}
+
+/* Alarm Panel */
+
+.alarm-disarmed {
+  fill: #3c763d !important;
+}
+
+.alarm-armed {
+  fill: #8a6d3b !important;
+}
+
+/* Camera */
+
+.camera-idle {
+  fill: #6faece !important;
+}
+
+/* Light */
+
+.light-off {
+  fill: #585959 !important;
+}
+
+.light-on {
+  fill: #ffffa6 !important;
+}
+
+.window-closed {
+  fill: #00adee !important;
+}
+
+.window-open {
+  fill: #a94442 !important;
+}
+
+/* Doors */
+
+.door,
+.slider,
+.slider > .fill {
+  transition: fill 2s ease, stroke 2s ease;
+  animation-duration: 2s;
+  animation-fill-mode: forwards;
+}
+.slider.open,
+.door.open,
+.slider.open > .fill {
+  fill: #a94442 !important;
+}
+.door.d-r {
+  transform: rotate(-45deg);
+}
+.door.d-l {
+  transform: rotate(45deg);
+}
+
+.door.closed { animation-name: doorClose; }
+.door.open { animation-name: doorOpen; }
+.door.ccw.closed { animation-name: doorCloseCCW; }
+.door.ccw.open { animation-name: doorOpenCCW; }
+.door.d-r.closed { animation-name: doorCloseDownRight; }
+.door.d-r.open { animation-name: doorOpenDownRight; }
+.door.d-l.closed { animation-name: doorCloseDownLeft; }
+.door.d-l.open { animation-name: doorOpenDownLeft; }
+
+/* Slider */
+
+.slider.horizontal.closed { animation-name: slideLeft; }
+.slider.horizontal.open { animation-name: slideRight; }
+.slider.vertical.closed { animation-name: slideDown; }
+.slider.vertical.open { animation-name: slideUp; }
+
+/* Doorbell */
+
+.doorbell-off {
+  fill: #c3b7f4 !important;
+}
+
+.doorbell-on {
+  fill: #f8d2b9 !important;
+}
+
+/* Temperature sensor */
+
+.temp-very-low-background {
+  fill: #d9edf7 !important;
+  fill-opacity: 1 !important;
+}
+
+.temp-below-average-background {
+  fill: #dcefe8 !important;
+  fill-opacity: 1 !important;
+}
+
+.temp-average-background {
+  fill: #dff0d8 !important;
+  fill-opacity: 1 !important;
+}
+
+.temp-very-high-background {
+  fill: #f2dede !important;
+  fill-opacity: 1 !important;
+}
+
+/* Media player, Device */
+
+.device-off,
+.mediaplayer-off {
+  fill: #a94442 !important;
+}
+
+.device-on,
+.mediaplayer-on {
+  fill: #d4ff2a !important;
+}
+
+.mediaplayer-idle {
+  fill: #8aa8a7 !important;
+}
+
+.mediaplayer-paused {
+  fill: #ffffa6 !important;
+}
+
+.mediaplayer-playing {
+  fill: #2baaa6 !important;
+}

--- a/www/custom_ui/floorplan/floorplan.svg
+++ b/www/custom_ui/floorplan/floorplan.svg
@@ -1,0 +1,2961 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="floorplan.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   id="svg1207"
+   version="1.1"
+   viewBox="0 0 1750 1094"
+   height="1094"
+   width="1750">
+  <sodipodi:namedview
+     fit-margin-bottom="0"
+     fit-margin-right="0"
+     fit-margin-left="0"
+     fit-margin-top="0"
+     units="px"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-11"
+     inkscape:window-x="-11"
+     inkscape:window-height="2066"
+     inkscape:window-width="3840"
+     showgrid="false"
+     inkscape:current-layer="svg1207"
+     inkscape:document-units="px"
+     inkscape:cy="562.33916"
+     inkscape:cx="1073.7854"
+     inkscape:zoom="1.6970563"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <defs
+     id="defs1201" />
+  <metadata
+     id="metadata1204">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="fill:#231f26"
+     id="background"
+     width="1750"
+     height="1094"
+     x="0"
+     y="0"
+     inkscape:label="Background" />
+  <g
+     inkscape:label="Basement"
+     id="basement">
+    <g
+       id="basement_structure"
+       inkscape:label="Structure">
+      <path
+         inkscape:label="Backdrop"
+         style="fill:#3d3b3f"
+         inkscape:connector-curvature="0"
+         d="m 665.41601,83.46397 c 337.94979,0 675.91199,0 1013.86179,0 0,110.44923 0,220.91082 0,331.36005 -68.8314,0 -137.6627,0 -206.4816,0 0,49.04871 0,98.08505 0,147.13378 -116.6436,0 -233.2748,0 -349.906,0 0,42.0382 0,84.0764 0,126.1146 -152.48728,0 -304.98688,0 -457.47419,0 0,-201.53613 0,-403.07228 0,-604.60843 z"
+         id="basement_structure_backdrop" />
+      <g
+         inkscape:label="Support"
+         id="basement_structure_support">
+        <g
+           inkscape:label="Bathtub"
+           id="g1314">
+          <path
+             inkscape:connector-curvature="0"
+             id="path5069-5"
+             d="M 772.25327,276.0829 H 668.7116"
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <rect
+             ry="7.9166665"
+             y="-766.62823"
+             x="229.20784"
+             height="94.583336"
+             width="42.916668"
+             id="rect5071-9"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             transform="rotate(90)" />
+          <circle
+             r="2.8125"
+             cy="-760.06573"
+             cx="250.35371"
+             id="path5073-7"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             transform="rotate(90)" />
+        </g>
+        <g
+           inkscape:label="Toilet"
+           id="g5479">
+          <rect
+             ry="2.06545"
+             rx="2.06545"
+             y="671.53308"
+             x="-323.06787"
+             height="10.625"
+             width="38.333332"
+             id="rect5175-5"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             transform="rotate(-90)" />
+          <ellipse
+             ry="16.40625"
+             rx="13.072917"
+             cy="698.56433"
+             cx="-303.64081"
+             id="path5177-6"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             transform="rotate(-90)" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5196-58"
+             d="m 682.26226,313.90122 h 6.14584"
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5196-5-82"
+             d="m 682.26226,293.38039 h 6.14584"
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        </g>
+        <g
+           inkscape:label="Bathroom Sink"
+           id="g5469">
+          <ellipse
+             ry="15.541617"
+             rx="18.41424"
+             cy="688.91144"
+             cx="-370.9259"
+             id="path5082-2"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             transform="rotate(-90)" />
+          <ellipse
+             ry="11.416828"
+             rx="16.499159"
+             cy="690.97382"
+             cx="-370.77863"
+             id="path5084-9"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             transform="rotate(-90)" />
+          <circle
+             r="1.620453"
+             cy="687.80658"
+             cx="-370.92584"
+             id="path5086-47"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             transform="rotate(-90)" />
+          <rect
+             ry="0.29462782"
+             rx="0.29462782"
+             y="674.84296"
+             x="-377.84967"
+             height="3.3882201"
+             width="13.700193"
+             id="rect5088-7"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             transform="rotate(-90)" />
+          <rect
+             ry="0.29462799"
+             rx="0.29462799"
+             y="675.40045"
+             x="-372.95465"
+             height="9.140625"
+             width="4.0104165"
+             id="rect5090-2"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             transform="rotate(-90)" />
+        </g>
+        <path
+           inkscape:label="Bathroom Counter"
+           inkscape:connector-curvature="0"
+           id="path5337"
+           d="m 705.78095,411.64196 v -82.05385 h -36.68116 m 3.31456,0 v 81.83288"
+           style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <g
+           inkscape:label="Shelves"
+           id="basement_structure_support_shelves">
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 668.95248,443.16713 h 98.99495"
+             id="path5511"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6, 1;stroke-dashoffset:0;stroke-opacity:1"
+             d="M 668.80516,439.77891 H 771.77759"
+             id="path5515"
+             inkscape:connector-curvature="0" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5521"
+             d="M 1143.3333,418.16667 V 557.95833"
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5523"
+             d="m 1146.7708,557.85417 v -139.375"
+             style="fill:none;stroke:#464646;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6, 1;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5531"
+             d="m 771.77759,112.59471 h -78.371 v 83.96893 h 78.371"
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5533"
+             d="M 771.66667,109.9375 H 690.625 v 89.89583 h 80.9375"
+             style="fill:none;stroke:#464646;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6, 1;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+        <rect
+           inkscape:label="Furnace"
+           y="420.66666"
+           x="1181.4584"
+           height="61.666668"
+           width="59.583332"
+           id="rect5535"
+           style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <circle
+           inkscape:label="Water Heater"
+           r="19.0625"
+           cy="537.4375"
+           cx="1233.0208"
+           id="path5543"
+           style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <circle
+           inkscape:label="Water Softener"
+           r="13.125"
+           cy="542.95837"
+           cx="1289.7916"
+           id="path5545"
+           style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         inkscape:label="Walls"
+         id="basement_structure_walls">
+        <path
+           id="basement_structure_walls_path_5"
+           d="m 661.70676,79.75472 h 246.04696 v 7.82652 c -42.8542,-0.0124 -85.7084,0.0371 -128.5503,-0.0247 -0.074,9.4957 -0.012,34.97913 -0.037,44.46246 h -7.8265 V 87.58124 H 669.53328 v 131.4807 H 771.33982 V 183.54 h 7.8265 v 169.87113 h -7.8265 c 0.012,-42.16185 -0.037,-84.32371 0.025,-126.49793 -33.95196,-0.0495 -67.90396,-0.0495 -101.85597,0 0.0495,61.38816 0.0495,122.77632 0,184.16447 33.95201,0.0618 67.90401,0.0618 101.85597,0 -0.025,-2.05245 -0.037,-4.1049 -0.037,-6.14499 h 7.8388 v 6.18209 h 27.0776 c 2.275,2.33683 4.6736,4.55002 6.8374,7.01049 -1.9412,1.68153 -3.7093,3.54852 -5.5268,5.37842 -1.5703,-1.57025 -3.1529,-3.14051 -4.7231,-4.71076 -16.1724,16.09817 -32.2458,32.29524 -48.4305,48.38104 -1.6444,-0.0124 -3.2765,-0.0124 -4.9086,-0.0124 v -7.70288 c 0.3984,-0.002 1.5479,-0.0131 1.9907,-0.0158 13.3285,-13.41514 26.7931,-27.11116 40.097,-40.57576 -40.6782,0.1731 -81.36863,0.0247 -122.04674,0.0742 -0.0124,13.45223 0.0371,26.90446 -0.0247,40.35669 3.04159,0.0371 6.08317,0.0371 9.12476,0.0618 -0.0247,2.60884 -0.0371,5.21768 -0.0495,7.82652 -3.01686,-0.0247 -6.03371,-0.0247 -9.05057,-0.0247 v 59.34807 h -7.82652 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 5"
+           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccc" />
+        <path
+           id="basement_structure_walls_path_4"
+           d="m 990.18562,79.75472 c 41.22208,0.0247 82.44428,-0.0495 123.66638,0.0371 -0.025,2.59648 -0.037,5.20532 -0.062,7.81416 -41.1974,-0.0495 -82.4072,-0.0124 -123.60458,-0.0247 -0.012,-2.60884 -0.012,-5.21768 0,-7.82652 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 4" />
+        <path
+           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccc"
+           id="basement_structure_walls_path_3"
+           d="m 1196.2221,79.79181 c 162.1313,-0.0618 324.2503,-0.0618 486.3816,0 -0.074,113.05807 0.025,226.11614 -0.049,339.17421 -68.6706,-0.0618 -137.3412,0.0247 -206.0118,-0.0494 -0.099,48.78905 0.025,97.57811 -0.074,146.36718 -116.7548,-0.062 -233.522,-0.012 -350.2769,-0.025 -0.025,42.3102 0.037,84.6328 -0.025,126.9554 -24.7283,-0.049 -49.4443,-0.012 -74.1603,-0.025 -0.012,-2.6212 -0.012,-5.2177 0,-7.8265 h 66.3462 c -0.012,-48.208 0.037,-96.4159 -0.025,-144.6239 2.6212,-0.049 5.2548,-0.049 7.8884,0 -0.062,5.8854 -0.025,11.7831 -0.025,17.6808 h 40.3814 c 0.012,-46.14315 -0.025,-92.29864 0.025,-138.44176 -13.4769,-0.0495 -26.9538,-0.0495 -40.4308,0 0.037,5.88535 0.012,11.78306 0.025,17.69314 -2.6212,-0.0124 -5.23,-0.0124 -7.8388,0 0.012,-5.91008 -0.025,-11.79543 0.025,-17.69314 -70.8838,-0.0865 -141.75518,0 -212.62658,-0.0495 -1.5703,1.6568 -3.1776,3.25178 -4.8839,4.76021 -1.768,-1.87936 -3.5856,-3.69689 -5.4155,-5.51443 2.3863,-2.33683 4.7232,-4.71075 7.0723,-7.05994 h 6.4665 201.12788 39.145 c -0.012,-2.21319 0,-4.41402 0.037,-6.61484 2.5841,0.0247 5.1682,0.0247 7.7647,0 0.025,2.20082 0.037,4.40165 0.037,6.61484 32.1468,0.0247 64.306,-0.0371 96.4652,0.0371 -0.025,2.59648 -0.037,5.20532 -0.05,7.81416 -26.3851,-0.0247 -52.7579,-0.0494 -79.1306,0.0124 0.049,46.14312 0.012,92.29861 0.025,138.44176 98.0726,0.012 196.1575,-0.012 294.2425,0.025 0.049,-46.16785 0,-92.3357 0.025,-138.50356 h -153.3157 c -0.012,-2.60884 -0.012,-5.21768 0,-7.82652 h 82.0115 V 387.192 c 2.5965,-0.0124 5.2054,-0.0124 7.8266,0 -0.012,19.90633 0.037,3.97909 -0.025,23.89779 89.8628,0.0618 179.7132,0 269.5636,0.0247 0.012,-107.82803 -0.025,-215.66841 0.025,-323.49643 -89.8504,-0.0742 -179.7131,-0.0124 -269.5635,-0.0371 v 237.62129 h -7.8266 c -0.025,-70.76021 0.037,-166.88581 -0.037,-237.64602 -67.0137,0.0742 -134.0399,-0.0124 -201.0537,0.0495 -0.037,-2.60884 -0.049,-5.21768 -0.062,-7.81416 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 3" />
+        <path
+           id="basement_structure_walls_path_2"
+           d="m 905.68892,342.28337 c 83.8043,0 167.60858,0 251.41298,0 0,4.7973 -0.037,9.59461 0.025,14.39191 -2.6336,0.0495 -5.2671,0.0495 -7.8883,0 0.025,-2.18846 0.025,-4.37692 0.025,-6.55302 -13.0442,-0.0124 -26.1008,0 -39.145,0 -67.0385,-0.0124 -134.08938,-0.0124 -201.12788,0 -0.8284,0 -2.4728,0 -3.3012,-0.0124 0,-2.60884 0,-5.21769 0,-7.82653 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 2" />
+        <path
+           id="basement_structure_walls_path_1"
+           d="m 843.97932,459.80491 c 1.9165,-1.73098 3.7216,-3.57325 5.5392,-5.40315 1.6197,1.60735 3.2394,3.23942 4.8467,4.87149 1.5579,-1.54552 3.091,-3.09104 4.6118,-4.64893 1.8423,1.80517 3.6104,3.69689 5.5763,5.36605 -1.459,1.65681 -3.0045,3.23942 -4.5871,4.78494 14.2435,14.293 28.487,28.61072 42.8418,42.81716 0,58.92773 0,117.84303 0,176.77073 22.2555,0 44.511,0 66.7665,0 0,2.6088 0,5.2177 0,7.8265 -102.6226,0 -205.2452,0 -307.86776,0 0,-27.7452 0,-55.5028 0,-83.248 2.60884,0 5.21768,-0.012 7.82652,0 -0.0124,25.124 0.0371,50.2604 -0.0247,75.3844 75.16174,0.062 150.33594,0.062 225.49764,0 -0.062,-57.2956 -0.025,-114.6036 -0.025,-171.89923 0.4575,-2.003 -1.6815,-2.93031 -2.7078,-4.21619 -16.0857,-16.14762 -32.3199,-32.14687 -48.2944,-48.40577 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 1" />
+      </g>
+      <g
+         inkscape:label="Stairs"
+         id="basement_structure_stairs">
+        <path
+           id="basement_structure_stairs_back"
+           d="m 908.99012,350.12226 c 67.03852,-0.0124 134.08938,-0.0124 201.12788,0 -0.012,20.32672 0,40.65343 0,60.99251 -67.0385,0 -134.08936,0 -201.12788,0 0,-20.33908 0,-40.66579 0,-60.99251 z"
+           inkscape:connector-curvature="0"
+           style="fill:#585959"
+           inkscape:label="Background" />
+        <path
+           id="basement_structure_stairs_line_12"
+           d="m 908.99012,350.53028 h 1.23642 c 0,20.19071 0,40.38142 0,60.58449 h -1.23642 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 12" />
+        <path
+           id="basement_structure_stairs_line_11"
+           d="m 926.29996,350.53028 h 1.23641 c 0,20.19071 0,40.38142 0,60.58449 h -1.23641 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 11" />
+        <path
+           id="basement_structure_stairs_line_10"
+           d="m 943.60979,350.53028 h 1.23642 c 0,20.19071 0,40.38142 0,60.58449 h -1.23642 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 10" />
+        <path
+           id="basement_structure_stairs_line_9"
+           d="m 960.91963,350.53028 h 1.23641 c 0,20.19071 0,40.38142 0,60.58449 h -1.23641 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 9" />
+        <path
+           id="basement_structure_stairs_line_8"
+           d="m 978.22946,350.53028 h 1.23642 c 0,20.19071 0,40.38142 0,60.58449 h -1.23642 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 8" />
+        <path
+           id="basement_structure_stairs_line_7"
+           d="m 995.5393,350.53028 h 1.23641 c 0,20.19071 0,40.38142 0,60.58449 h -1.23641 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 7" />
+        <path
+           id="basement_structure_stairs_line_6"
+           d="m 1012.8491,350.53028 h 1.2364 c 0,20.19071 0,40.38142 0,60.58449 h -1.2364 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 6" />
+        <path
+           id="basement_structure_stairs_line_5"
+           d="m 1030.159,350.53028 h 1.2364 c 0,20.19071 0,40.38142 0,60.58449 h -1.2364 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 5" />
+        <path
+           id="basement_structure_stairs_line_4"
+           d="m 1047.4688,350.53028 h 1.2364 c 0,20.19071 0,40.38142 0,60.58449 h -1.2364 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 4" />
+        <path
+           id="basement_structure_stairs_line_3"
+           d="m 1064.7786,350.53028 h 1.2365 c 0,20.19071 0,40.38142 0,60.58449 h -1.2365 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 3" />
+        <path
+           id="basement_structure_stairs_line_2"
+           d="m 1082.0885,350.53028 h 1.2364 c 0,20.19071 0,40.38142 0,60.58449 h -1.2364 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 2" />
+        <path
+           id="basement_structure_stairs_line_1"
+           d="m 1099.3983,350.53028 h 1.2364 c 0,20.19071 0,40.38142 0,60.58449 h -1.2364 c 0,-20.20307 0,-40.39378 0,-60.58449 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 1" />
+        <path
+           style="fill:#00adee"
+           inkscape:connector-curvature="0"
+           d="m 924.0451,381.00412 -13.8416,7.63671 0.95462,-4.05699 h -7.15945 v -7.15945 h 7.15945 l -0.71595,-4.05702 z"
+           class="st9"
+           id="basement_structure_stairs_arrow"
+           inkscape:label="Arrow" />
+      </g>
+      <g
+         inkscape:label="Windows"
+         id="basement_structure_windows">
+        <rect
+           id="windows_bedroom-4"
+           width="82.500023"
+           height="14.399989"
+           x="969.57452"
+           y="684.36322"
+           style="fill:#505050"
+           inkscape:label="Bedroom 4" />
+        <rect
+           id="windows_bedroom-3"
+           width="14.400003"
+           height="82.499939"
+           x="655.13318"
+           y="526.50983"
+           style="fill:#505050"
+           inkscape:label="Bedroom 3" />
+        <rect
+           id="windows_family_room-2"
+           width="82.500023"
+           height="14.399989"
+           x="1113.7902"
+           y="73.206421"
+           style="fill:#505050"
+           inkscape:label="Family Room 2" />
+        <rect
+           id="windows_family_room-1"
+           width="82.500023"
+           height="14.399989"
+           x="907.75372"
+           y="73.181702"
+           style="fill:#505050"
+           inkscape:label="Family Room 1" />
+      </g>
+      <g
+         inkscape:label="Closet Bedroom 4"
+         id="basement_structure_closet_4">
+        <path
+           inkscape:label="Path 2"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 1083.5845,519.53627 c 11.474,-6.67666 23.0097,-13.27913 34.496,-19.93106 0.4328,0.69239 1.2859,2.08955 1.7187,2.78194 -10.1139,5.84826 -20.2402,11.68415 -30.3541,17.53241 10.1139,5.84826 20.2278,11.68414 30.3541,17.52004 -0.4328,0.7048 -1.2983,2.1019 -1.7187,2.7943 -10.6331,-6.1079 -21.2169,-12.31471 -31.8871,-18.3608 -0.8284,-0.77894 -2.8067,-0.90258 -2.6089,-2.33683 z"
+           id="basement_structure_closet_4-2" />
+        <path
+           inkscape:label="Path 1"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 1083.1023,456.24403 c 11.7583,-6.59011 23.3436,-13.45223 35.0401,-20.15362 0.3091,0.74185 0.9273,2.21319 1.2364,2.94268 -9.8419,5.94717 -19.8692,11.60996 -29.8718,17.29749 9.9531,6.1079 20.1906,11.7336 30.2798,17.63132 -0.4327,0.69239 -1.2982,2.10191 -1.731,2.80667 -11.5852,-6.93631 -23.6155,-13.20495 -34.9535,-20.52454 z"
+           id="basement_structure_closet_4-1" />
+      </g>
+      <g
+         inkscape:label="Closet Bedroom 3"
+         id="basement_structure_closet_3">
+        <path
+           inkscape:label="Path 2"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 747.22972,465.73972 c 0.9397,0.55639 1.867,1.12514 2.8067,1.68153 -5.2795,9.12476 -10.48486,18.27426 -15.82618,27.36193 -5.09403,-9.23604 -10.83101,-18.13825 -15.60358,-27.53503 0.66767,-0.38329 2.01536,-1.12514 2.68303,-1.50843 4.33982,7.48033 8.49418,15.05957 13.01947,22.41626 4.30273,-7.48033 8.60546,-14.9483 12.92056,-22.41626 z"
+           id="basement_structure_closet_3-2" />
+        <path
+           inkscape:label="Path 1"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 678.0151,467.38416 c 0.79131,-0.37093 2.34919,-1.12515 3.12813,-1.50844 3.95654,7.61634 8.49419,14.89884 12.71037,22.37917 4.35219,-7.50506 8.64255,-15.04721 13.01947,-22.5399 0.70476,0.45748 2.139,1.36006 2.84376,1.81754 -5.46497,8.97639 -10.54664,18.18771 -15.86323,27.26301 -5.29187,-9.12476 -10.52191,-18.28662 -15.8385,-27.41138 z"
+           id="basement_structure_closet_3-1" />
+      </g>
+      <g
+         id="basement_structure_doors"
+         inkscape:label="Doors">
+        <path
+           id="2668_door_bedroom_4"
+           d="m 900.51962,424.02136 c 18.7811,18.42671 20.2,47.84024 3.545,68.39321 l -35.9677,-35.96777 -3.5436,3.54357 36.6764,36.67649 c 20.1986,-20.19874 20.1987,-52.79987 10e-5,-72.99849 v 0 l -0.1773,-0.1773 z"
+           inkscape:connector-curvature="0"
+           style="fill:#505050"
+           inkscape:label="#2668 Door Bedroom 4" />
+        <path
+           inkscape:label="#2668 Door Bedroom 3"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 843.52342,459.47002 c -18.4267,18.78115 -47.8401,20.20006 -68.3931,3.54505 l 35.9677,-35.96777 -3.5435,-3.54362 -36.6765,36.67641 c 20.1987,20.19863 52.7998,20.19881 72.9984,1.6e-4 v 0 l 0.1773,-0.17729 z"
+           id="2668_door_bedroom_3" />
+        <path
+           inkscape:label="#3068 Door Utility"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 1315.2505,418.96367 c 0.3041,31.93062 -23.72,58.3901 -55.6508,61.73522 v -61.73287 h -6.0821 v 62.94914 c 34.6677,0 62.6452,-27.97718 62.6452,-62.64486 v 0 -0.30428 z"
+           id="3068_door_utility" />
+        <path
+           id="2468_door_stairs"
+           d="m 1157.063,358.0571 c 24.0221,-0.22886 43.9281,17.84497 46.4447,41.86722 h -46.4429 v 4.57561 h 47.3579 c 0,-26.08125 -21.0478,-47.12929 -47.129,-47.12929 v 0 h -0.2289 z"
+           inkscape:connector-curvature="0"
+           style="fill:#505050"
+           inkscape:label="#2468 Door Stairs" />
+        <path
+           id="2668_door_bathroom_2"
+           d="m 771.32932,354.06671 c -26.3099,-0.25064 -48.11166,19.54454 -50.86795,45.85457 h 50.86605 l 1e-4,5.0114 -51.86834,6e-5 c 9e-5,-28.56527 23.05244,-51.61787 51.61754,-51.61785 v 0 l 0.2508,-10e-6 z"
+           inkscape:connector-curvature="0"
+           style="fill:#505050"
+           inkscape:label="#2668 Door Bathroom 2" />
+        <path
+           inkscape:label="#2668 Door Storage"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 779.16452,182.88497 c 26.3099,0.25063 48.1117,-19.54455 50.86798,-45.85457 h -50.86608 v -5.0114 l 51.86827,-6e-5 c -9e-5,28.56526 -23.05247,51.61787 -51.61757,51.61784 v 0 l -0.2507,2e-5 z"
+           id="2668_door_storage" />
+        <path
+           inkscape:label="#3068 Door Theater"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 1397.3777,325.4591 c -31.9306,-0.3041 -58.3901,23.72 -61.7352,55.6508 h 61.7329 v 6.0821 h -62.9491 c 0,-34.6677 27.9771,-62.6452 62.6448,-62.6452 v 0 h 0.3043 z"
+           id="3068_door_theater" />
+      </g>
+      <g
+         inkscape:label="Labels"
+         id="basement_structure_labels">
+        <text
+           transform="rotate(-90)"
+           inkscape:label="Utility Room"
+           id="text_utility_room"
+           y="1193.1052"
+           x="-514.9585"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641741"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290298"
+             y="1193.1052"
+             x="-514.9585"
+             id="tspan1680"
+             sodipodi:role="line">UTILITY</tspan></text>
+        <text
+           transform="rotate(-90)"
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641741"
+           x="-618.57397"
+           y="921.62433"
+           id="text_bedroom_4"
+           inkscape:label="Bedroom 4"><tspan
+             sodipodi:role="line"
+             id="tspan1664"
+             x="-618.57397"
+             y="921.62433"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290298">BEDROOM 4</tspan></text>
+        <text
+           transform="rotate(-90)"
+           inkscape:label="Bedroom 3"
+           id="text_bedroom_3"
+           y="688.33984"
+           x="-618.59497"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641741"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290298"
+             y="688.33984"
+             x="-618.59497"
+             id="tspan1660"
+             sodipodi:role="line">BEDROOM 3</tspan></text>
+        <text
+           transform="rotate(-90)"
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641741"
+           x="-358.60593"
+           y="1672.5331"
+           id="text_theater_room"
+           inkscape:label="Theater Room"><tspan
+             sodipodi:role="line"
+             id="tspan1656"
+             x="-358.60593"
+             y="1672.5331"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290298">THEATER</tspan></text>
+        <text
+           transform="rotate(-90)"
+           inkscape:label="Family Room"
+           id="text_family_room"
+           y="797.9328"
+           x="-302.55331"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641741"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290298"
+             y="797.9328"
+             x="-302.55331"
+             id="tspan1652"
+             sodipodi:role="line">FAMILY</tspan></text>
+        <text
+           transform="rotate(-90)"
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641741"
+           x="-380.54666"
+           y="688.10236"
+           id="text_bsmt_bathroom"
+           inkscape:label="Bsmt Bathroom"><tspan
+             sodipodi:role="line"
+             id="tspan1630-3"
+             x="-380.54666"
+             y="688.10236"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38752365px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290298">BATH</tspan></text>
+      </g>
+    </g>
+    <g
+       inkscape:label="Doors"
+       id="basement_doors">
+      <rect
+         style="fill:#00adee"
+         id="sensor.door_utility"
+         width="62"
+         height="7"
+         x="1253.5176"
+         y="411.96603"
+         inkscape:label="#3068 Door Utility"
+         class="origin-bl door" />
+      <rect
+         style="fill:#00adee"
+         id="rect9956"
+         width="7"
+         height="48"
+         x="1150.0656"
+         y="356.49933"
+         inkscape:label="#2468 Door Stairs"
+         class="origin-br door" />
+      <rect
+         y="325.19199"
+         style="fill:#00adee;stroke-width:0.9949972"
+         id="sensor.door_theater"
+         width="7"
+         height="62"
+         x="1397.3754"
+         inkscape:label="#2668 Door Theater"
+         class="origin-bl door ccw" />
+      <rect
+         style="fill:#00adee"
+         id="sensor.door_bedroom_4"
+         width="52"
+         height="7"
+         x="864.55334"
+         y="452.99036"
+         inkscape:label="#2668 Door Bedroom 4"
+         class="origin-bl door d-r" />
+      <rect
+         style="fill:#00adee"
+         id="sensor.door_bedroom_3"
+         width="7"
+         height="52"
+         x="807.55481"
+         y="423.50369"
+         inkscape:label="#2668 Door Bedroom 3"
+         class="origin-tl door d-r" />
+      <rect
+         style="fill:#00adee"
+         id="sensor.door_bathroom_2"
+         width="7"
+         height="52"
+         x="771.32751"
+         y="352.93268"
+         class="origin-bl door ccw"
+         inkscape:label="#2668 Door Bathroom 2" />
+      <rect
+         style="fill:#00adee"
+         id="sensor.door_storage"
+         width="7"
+         height="52"
+         x="772.16644"
+         y="132.019"
+         class="origin-tr door ccw"
+         inkscape:label="#2668 Door Storage" />
+    </g>
+    <g
+       id="basement_windows"
+       inkscape:label="Windows">
+      <rect
+         inkscape:label="sensor.window_bedroom_4"
+         style="fill:#29d8c2"
+         y="684.36322"
+         x="969.57452"
+         height="14.4"
+         width="82.5"
+         id="sensor.window_bedroom_4" />
+      <rect
+         inkscape:label="sensor.window_bedroom_3"
+         style="fill:#29d8c2"
+         y="526.5097"
+         x="655.1333"
+         height="82.5"
+         width="14.4"
+         id="sensor.window_bedroom_3" />
+      <rect
+         inkscape:label="sensor.window_family_room_2"
+         style="fill:#29d8c2"
+         y="73.205994"
+         x="1113.7902"
+         height="14.4"
+         width="82.5"
+         id="sensor.window_family_room_2" />
+      <rect
+         inkscape:label="sensor.window_family_room_1"
+         style="fill:#29d8c2"
+         y="73.181274"
+         x="907.75372"
+         height="14.4"
+         width="82.5"
+         id="sensor.window_family_room_1" />
+    </g>
+    <g
+       id="basement_lights"
+       inkscape:label="Lights">
+      <ellipse
+         inkscape:label="switch.bedroom4_light_switch"
+         ry="12.529034"
+         rx="12.529029"
+         cy="550.86133"
+         cx="1011.813"
+         id="switch.bedroom4_light_switch"
+         style="display:none;fill:#585959" />
+      <ellipse
+         inkscape:label="switch.bedroom3_light_switch"
+         ry="12.529034"
+         rx="12.529029"
+         cy="573.89569"
+         cx="783.24164"
+         id="switch.bedroom3_light_switch"
+         style="display:none;fill:#585959" />
+      <ellipse
+         inkscape:label="switch.basement_hallway_light_switch"
+         ry="12.529034"
+         rx="12.529029"
+         cy="375.44592"
+         cx="876.77423"
+         id="switch.basement_hallway_light_switch"
+         style="fill:#585959" />
+      <ellipse
+         inkscape:label="switch.basement_bathroom_light_switch"
+         ry="12.529034"
+         rx="12.529029"
+         cy="358.86368"
+         cx="719.45416"
+         id="switch.basement_bathroom_light_switch"
+         style="display:none;fill:#585959" />
+      <ellipse
+         inkscape:label="switch.storage_light_switch"
+         ry="12.529034"
+         rx="12.529029"
+         cy="158.8161"
+         cx="720.74969"
+         id="switch.storage_light_switch"
+         style="display:none;fill:#585959" />
+      <ellipse
+         inkscape:label="switch.stairs_closet_light_switch"
+         ry="12.529034"
+         rx="12.529029"
+         cy="381.02466"
+         cx="1131.233"
+         id="switch.stairs_closet_light_switch"
+         style="display:none;fill:#585959" />
+      <ellipse
+         inkscape:label="switch.utility_light_switch"
+         ry="12.529034"
+         rx="12.529029"
+         cy="485.56519"
+         cx="1363.3483"
+         id="switch.utility_light_switch"
+         style="display:none;fill:#585959" />
+      <g
+         style="display:none"
+         inkscape:label="light.theater_walls_level"
+         id="light.theater_walls_level">
+        <ellipse
+           inkscape:label="light.theater_walls_level-2"
+           ry="12.529034"
+           rx="12.529029"
+           cy="274.83777"
+           cx="1659.9941"
+           id="light.theater_walls_level-2"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.theater_walls_level-1"
+           ry="12.529034"
+           rx="12.529029"
+           cy="274.83777"
+           cx="1420.8237"
+           id="light.theater_walls_level-1"
+           style="fill:#585959" />
+      </g>
+      <g
+         style="display:none"
+         inkscape:label="light.theater_room_level"
+         id="light.theater_room_level">
+        <ellipse
+           inkscape:label="light.theater_room_level-4"
+           ry="12.529034"
+           rx="12.529029"
+           cy="320.64014"
+           cx="1607.1066"
+           id="light.theater_room_level-4"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.theater_room_level-3"
+           ry="12.529034"
+           rx="12.529029"
+           cy="320.64014"
+           cx="1483.4501"
+           id="light.theater_room_level-3"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.theater_room_level-2"
+           ry="12.529034"
+           rx="12.529029"
+           cy="172.24252"
+           cx="1607.1066"
+           id="light.theater_room_level-2"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.theater_room_level-1"
+           ry="12.529034"
+           rx="12.529029"
+           cy="172.24252"
+           cx="1483.4501"
+           id="light.theater_room_level-1"
+           style="fill:#585959" />
+      </g>
+      <g
+         inkscape:label="light.vr_space_level"
+         id="light.vr_space_level">
+        <ellipse
+           inkscape:label="light.vr_space_level-4"
+           ry="12.529034"
+           rx="12.529029"
+           cy="248.79095"
+           cx="1338.7583"
+           id="light.vr_space_level-4"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.vr_space_level-3"
+           ry="12.529034"
+           rx="12.529029"
+           cy="248.79095"
+           cx="1217.2032"
+           id="light.vr_space_level-3"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.vr_space_level-2"
+           ry="12.529034"
+           rx="12.529"
+           cy="158.35497"
+           cx="1338.7583"
+           id="light.vr_space_level-2"
+           style="fill:#585959;stroke-width:0.99999887" />
+        <ellipse
+           inkscape:label="light.vr_space_level-1"
+           ry="12.529034"
+           rx="12.529029"
+           cy="158.35497"
+           cx="1217.2032"
+           id="light.vr_space_level-1"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.vr_space_level-3"
+           ry="12.529034"
+           rx="12.529029"
+           cy="338.41669"
+           cx="1217.203"
+           id="light.vr_space_level-3-6"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.vr_space_level-3"
+           ry="12.529034"
+           rx="12.529029"
+           cy="338.41696"
+           cx="1338.7581"
+           id="light.vr_space_level-3-7"
+           style="fill:#585959" />
+      </g>
+      <g
+         inkscape:label="light.family_room_level"
+         id="light.family_room_level">
+        <ellipse
+           inkscape:label="light.family_room_level-6"
+           ry="12.529034"
+           rx="12.529029"
+           cy="268.79053"
+           cx="1099.4005"
+           id="light.family_room_level-6"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.family_room_level-5"
+           ry="12.529034"
+           rx="12.529029"
+           cy="268.79095"
+           cx="988.33331"
+           id="light.family_room_level-5"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.family_room_level-4"
+           ry="12.529034"
+           rx="12.529029"
+           cy="268.79053"
+           cx="874.80688"
+           id="light.family_room_level-4"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.family_room_level-3"
+           ry="12.529034"
+           rx="12.529029"
+           cy="158.35461"
+           cx="1099.4005"
+           id="light.family_room_level-3"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.family_room_level-2"
+           ry="12.529034"
+           rx="12.529029"
+           cy="158.35497"
+           cx="988.33331"
+           id="light.family_room_level-2"
+           style="fill:#585959" />
+        <ellipse
+           inkscape:label="light.family_room_level-1"
+           ry="12.529034"
+           rx="12.529029"
+           cy="158.35461"
+           cx="874.80688"
+           id="light.family_room_level-1"
+           style="fill:#585959" />
+      </g>
+    </g>
+    <g
+       id="basement_fans"
+       inkscape:label="Fans"
+       style="display:none">
+      <g
+         inkscape:label="fan_bathroom_2"
+         id="fan_bathroom_2">
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 706.37596,289.11471 c -0.83946,-0.83946 -2.09864,-0.76951 -2.86814,0.27981 -2.1686,3.5677 -1.81883,8.46453 1.25918,11.54254 3.07801,3.078 7.83493,3.63764 11.54253,1.25918 0.97937,-0.69955 1.11928,-2.02869 0.27982,-2.86814 -2.37846,-2.30851 -7.62507,-7.62507 -10.21339,-10.21339 z"
+           id="path1275-1" />
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 731.69957,312.47959 c 0.83946,0.83945 2.09864,0.7695 2.86815,-0.27982 2.16859,-3.56769 1.81882,-8.46453 -1.25919,-11.54253 -3.14796,-3.14797 -7.83493,-3.63765 -11.54253,-1.25919 -0.97937,0.69955 -1.18923,1.95873 -0.27982,2.86815 2.37846,2.37846 7.62507,7.62506 10.21339,10.21339 z"
+           id="path1277-3" />
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 730.79016,288.13534 c 0.83946,-0.83946 0.7695,-2.09864 -0.27982,-2.86814 -3.56769,-2.1686 -8.46452,-1.81883 -11.54253,1.25918 -3.07801,3.07801 -3.63764,7.90489 -1.32914,11.61249 0.69955,0.97936 2.02869,1.11927 2.86815,0.27982 2.3085,-2.23856 7.76497,-7.69503 10.28334,-10.28335 z"
+           id="path1279-5" />
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 707.42528,313.59886 c -0.83946,0.83946 -0.7695,2.09864 0.27982,2.86815 3.56769,2.16859 8.46452,1.81882 11.54253,-1.25919 3.07801,-3.07801 3.63765,-7.83493 1.25919,-11.54253 -0.69955,-0.97937 -2.02869,-1.11928 -2.86815,-0.27982 -2.23855,2.23855 -7.62506,7.62507 -10.21339,10.21339 z"
+           id="path1281-0" />
+      </g>
+    </g>
+    <g
+       inkscape:label="Devices"
+       id="basement_devices">
+      <g
+         id="sensor.device_rmjclarkmbpr15"
+         inkscape:label="sensor.device_rmjclarkmbpr15">
+        <path
+           inkscape:connector-curvature="0"
+           id="path10"
+           d="m 1109.483,670.99822 c 0,0 0,-20.44928 0,-20.44928 0,-0.17349 -0.1405,-0.31399 -0.314,-0.31399 0,0 -33.3762,0 -33.3762,0 -0.1735,0 -0.314,0.1405 -0.314,0.31399 0,0 0,20.44928 0,20.44928 0,0.17349 0.1405,0.31399 0.314,0.31399 0,0 33.3757,0 33.3757,0 0.1735,0 0.3145,-0.1405 0.3145,-0.31399 0,0 0,0 0,0 m -0.628,-0.314 c 0,0 -32.7482,0 -32.7482,0 0,0 0,-19.82128 0,-19.82128 10.1262,6.11598 22.1689,13.35151 32.7482,19.82128 0,0 0,0 0,0"
+           style="fill:#d4ff2a;stroke-width:0.7070989" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path12-8"
+           d="m 1114.6669,671.68621 c 0,0 -2.6725,0 -2.6725,0 0,0 0,-21.56376 0,-21.56376 0,-1.32299 -1.076,-2.39897 -2.3989,-2.39897 0,0 -34.2292,0 -34.2292,0 -1.3229,0 -2.3989,1.07598 -2.3989,2.39897 0,0 0,21.56376 0,21.56376 0,0 -2.672,0 -2.672,0 -0.1735,0 -0.314,0.1405 -0.314,0.314 0,0 0,0.36249 0,0.36249 0,1.63798 1.2215,2.97047 2.7235,2.97047 0,0 39.553,0 39.553,0 1.5015,0 2.7235,-1.33249 2.7235,-2.97047 0,0 0,-0.36249 0,-0.36249 -5e-4,-0.1735 -0.141,-0.314 -0.3145,-0.314 0,0 0,0 0,0 m -41.0715,-21.56376 c 0,-0.97649 0.7944,-1.77098 1.7709,-1.77098 0,0 34.2292,0 34.2292,0 0.9764,0 1.7709,0.79449 1.7709,1.77098 0,0 0,21.56376 0,21.56376 0,0 -15.1163,0 -15.1163,0 0,0 -7.5379,0 -7.5379,0 0,0 -15.1168,0 -15.1168,0 0,0 0,-21.56376 0,-21.56376 m 22.3407,22.19175 c 0,0 0,0.88199 0,0.88199 0,0 -6.9099,0 -6.9099,0 0,0 0,-0.88199 0,-0.88199 0,0 6.9099,0 6.9099,0 m 18.4168,0.0485 c 0,1.29199 -0.94,2.34248 -2.0955,2.34248 0,0 -39.5525,0 -39.5525,0 -1.1555,0 -2.0955,-1.05099 -2.0955,-2.34248 0,0 0,-0.0485 0,-0.0485 0,0 17.7888,0 17.7888,0 0,0 0,1.19599 0,1.19599 0,0.1735 0.1405,0.314 0.314,0.314 0,0 7.5379,0 7.5379,0 0.1735,0 0.314,-0.1405 0.314,-0.314 0,0 0,-1.19599 0,-1.19599 0,0 17.7888,0 17.7888,0 0,0 0,0.0485 0,0.0485"
+           style="fill:#d4ff2a;stroke-width:0.7070989" />
+      </g>
+      <path
+         id="sensor.device_erebus"
+         d="m 1094.6711,600.75392 c 0,0 12,0 12,0 0.7957,0 1.5587,0.3161 2.1213,0.8787 0.5626,0.5626 0.8787,1.3257 0.8787,2.1213 0,0 0,24 0,24 0,0.7957 -0.3161,1.5587 -0.8787,2.1214 -0.5626,0.5626 -1.3256,0.8786 -2.1213,0.8786 0,0 -12,0 -12,0 -0.7956,0 -1.5587,-0.316 -2.1213,-0.8786 -0.5626,-0.5627 -0.8787,-1.3257 -0.8787,-2.1214 0,0 0,-24 0,-24 0,-0.7956 0.3161,-1.5587 0.8787,-2.1213 0.5626,-0.5626 1.3257,-0.8787 2.1213,-0.8787 m 0,3 c 0,0 0,3 0,3 0,0 12,0 12,0 0,0 0,-3 0,-3 0,0 -12,0 -12,0 m 12,6 c 0,0 -12,0 -12,0 0,0 0,3 0,3 0,0 12,0 12,0 0,0 0,-3 0,-3 m 0,15 c 0,0 -3,0 -3,0 0,0 0,3 0,3 0,0 3,0 3,0 0,0 0,-3 0,-3"
+         style="fill:#d4ff2a"
+         inkscape:connector-curvature="0"
+         inkscape:label="sensor.device_erebus" />
+      <g
+         id="sensor.device_nasya"
+         inkscape:label="sensor.device_nasya">
+        <path
+           d="m 953.28339,535.4791 c -0.093,-0.0273 -1.97081,-0.43041 -17.13734,-3.59835 0,0 -0.83302,-0.17376 -0.83302,-0.17376 -0.17377,-0.0369 -0.34808,-0.0257 -0.51864,0.0321 0,0 -0.26519,0.0898 -0.26519,0.0898 0,0 -6.77538,-16.15087 -6.77538,-16.15087 -0.14918,-0.36999 -0.53628,-0.74213 -0.9421,-0.71272 0,0 -18.93812,-0.29621 -18.93812,-0.29621 -0.18339,-0.002 -0.34059,0.0727 -0.44806,0.20425 0,0 -0.55392,0.58653 -0.55392,0.58653 -0.0363,0.038 -0.054,0.0845 -0.0636,0.1326 -0.10159,0.20906 -0.10106,0.45929 0.006,0.72716 0,0 4.57199,11.42382 4.57199,11.42382 -0.30904,0.95653 -2.98401,9.24397 -3.52991,10.92017 -0.0433,0.13313 0,0.28337 0.11496,0.40261 0.0995,0.10265 0.23258,0.15879 0.36571,0.15879 0.0439,0 0.0877,-0.006 0.131,-0.0187 0.51061,-0.14596 5.67395,-1.66818 6.71496,-1.97508 0,0 0.82821,2.06972 0.82821,2.06972 0.14436,0.36144 0.41116,0.61166 0.69026,0.69775 0.038,0.0208 0.0797,0.0358 0.12565,0.0358 0.005,0 0.01,0 0.0139,-5.3e-4 0,0 0.0283,-0.002 0.0283,-0.002 0.0102,5.4e-4 0.0203,0.006 0.0305,0.006 0.0225,0 0.0444,-0.009 0.0668,-0.0112 0,0 0.40368,-0.0209 0.40368,-0.0209 0.007,-5.4e-4 0.0123,-0.004 0.0192,-0.005 0.30904,0.31439 0.84746,0.0909 1.03353,0.0123 0.16093,-0.0684 1.36823,-0.50847 1.82002,-0.67262 0.0364,-0.0128 0.0679,-0.0337 0.0941,-0.0583 6.38292,1.72058 19.50808,5.25745 19.68933,5.30182 0.11389,0.0273 0.34808,0.0839 0.61541,0.0839 0.24542,0 0.51864,-0.0476 0.75068,-0.21013 0.26734,-0.18714 6.41822,-4.32337 9.7225,-6.54547 1.36662,-0.9191 2.32476,-1.56338 2.35149,-1.58156 0.13741,-0.0957 0.21066,-0.28017 0.18179,-0.45982 -0.0299,-0.18821 -0.16628,-0.33471 -0.36518,-0.39299 0,0 4.9e-4,10e-4 4.9e-4,10e-4 m -1.41314,0.22564 c -0.4518,0.29407 -1.20302,0.78276 -2.10929,1.37197 -0.12458,0.0813 -0.25611,0.16682 -0.3855,0.25076 0,0 -6.01507,-1.44308 -6.01507,-1.44308 -0.2807,-0.0668 -0.57691,-0.0337 -0.83516,0.0941 0,0 -4.70405,2.32529 -4.70405,2.32529 -0.1,0.0497 -0.1588,0.15613 -0.14704,0.26734 0.0112,0.11121 0.0909,0.20371 0.19944,0.23151 0,0 6.62513,1.69706 6.62513,1.69706 -1.96492,1.27893 -3.54542,2.30978 -3.68711,2.4087 -0.28765,0.2005 -0.7742,0.0839 -0.93407,0.0444 -0.0941,-0.0225 -3.67588,-0.9437 -7.89177,-2.02802 0,0 13.47697,-6.55081 13.47697,-6.55081 3.0364,0.63358 5.1751,1.07897 6.40752,1.3308 0,0 0,-2e-5 0,-2e-5 m -10.26786,-0.0492 c 0,0 -0.11603,0.0567 -0.11603,0.0567 0,0 -1.11372,-0.28658 -1.11372,-0.28658 0,0 0.0989,-0.0454 0.0989,-0.0454 0.0219,0.0123 0.0439,0.0257 0.07,0.0315 0,0 1.06085,0.24378 1.06085,0.24378 m -0.35342,-0.62985 c 0,0 0.15559,-0.0711 0.15559,-0.0711 0.0192,0.01 0.0369,0.0219 0.0588,0.0267 0,0 1.03085,0.24007 1.03085,0.24007 0,0 -0.15024,0.0733 -0.15024,0.0733 -0.0241,-0.015 -0.0497,-0.0289 -0.0791,-0.0358 0,0 -1.0159,-0.23317 -1.0159,-0.23317 m -16.97962,1.7532 c 0,0 1.05224,0.27268 1.05224,0.27268 0,0 -0.64642,0.23846 -0.64642,0.23846 0,0 -0.99984,-0.30369 -0.99984,-0.30369 0,0 0.59402,-0.20745 0.59402,-0.20745 m -0.33043,-0.77849 c 0,0 0.53735,-0.185 0.53735,-0.185 0.0294,0.0246 0.0631,0.0444 0.10212,0.0545 0,0 0.38336,0.10052 0.38336,0.10052 0,0 -0.47853,0.16735 -0.47853,0.16735 0,0 -0.5443,-0.13737 -0.5443,-0.13737 m 1.64573,0.31813 c 0.0294,0.0251 0.0626,0.0455 0.10212,0.0561 0,0 0.84425,0.23045 0.84425,0.23045 0,0 -0.35342,0.13046 -0.35342,0.13046 -0.0203,-0.0118 -0.0401,-0.0251 -0.0642,-0.031 0,0 -0.93675,-0.24275 -0.93675,-0.24275 0,0 0.408,-0.14326 0.408,-0.14326 m -0.24167,-0.80094 c 0,0 0.23525,-0.0807 0.23525,-0.0807 0.0246,0.0155 0.0508,0.0299 0.0807,0.0369 0,0 0.43469,0.10105 0.43469,0.10105 0,0 -0.25451,0.0888 -0.25451,0.0888 -0.0225,-0.0139 -0.0449,-0.0278 -0.0722,-0.0353 0,0 -0.42393,-0.11075 -0.42393,-0.11075 m 1.46714,0.37267 c 0.0257,0.0176 0.054,0.0326 0.0856,0.0406 0,0 0.87633,0.21601 0.87633,0.21601 0,0 -0.40368,0.14918 -0.40368,0.14918 -0.0225,-0.0139 -0.0444,-0.0283 -0.0711,-0.0358 0,0 -0.86831,-0.23686 -0.86831,-0.23686 0,0 0.38116,-0.13313 0.38116,-0.13313 m -0.31065,-0.77047 c 0,0 0.1588,-0.0545 0.1588,-0.0545 0,0 0.25344,-0.0861 0.25344,-0.0861 0.006,0.003 0.0112,0.007 0.0182,0.01 0,0 0.45286,0.1342 0.45286,0.1342 0,0 -0.36678,0.12832 -0.36678,0.12832 -0.0171,-0.008 -0.0326,-0.0192 -0.0513,-0.0235 0,0 -0.46522,-0.10842 -0.46522,-0.10842 m 1.46715,0.36572 c 0,0 0.95225,0.23793 0.95225,0.23793 0,0 -0.25664,0.0946 -0.25664,0.0946 -0.004,-0.002 -0.007,-0.005 -0.0118,-0.006 0,0 -0.94904,-0.23419 -0.94904,-0.23419 0,0 0.26523,-0.0923 0.26523,-0.0923 m -0.18447,-0.80147 c 0,0 0.29354,-0.0994 0.29354,-0.0994 0.0166,0.009 0.0316,0.0208 0.0508,0.0267 0,0 0.39299,0.11496 0.39299,0.11496 0,0 -0.27375,0.0957 -0.27375,0.0957 0,0 -0.46358,-0.13796 -0.46358,-0.13796 m 1.40138,0.37587 c 0.0171,0.009 0.0321,0.0192 0.0508,0.0246 0,0 0.84425,0.21119 0.84425,0.21119 0,0 -0.26948,0.0994 -0.26948,0.0994 0,0 -0.92338,-0.23044 -0.92338,-0.23044 0,0 0.29781,-0.10475 0.29781,-0.10475 m -0.24541,-0.76832 c 0,0 0.21387,-0.0727 0.21387,-0.0727 0.0176,0.01 0.0337,0.0214 0.054,0.0267 0,0 0.39191,0.1032 0.39191,0.1032 0,0 -0.21119,0.0738 -0.21119,0.0738 0,0 -0.44859,-0.131 -0.44859,-0.131 m 2.35737,0.0294 c 0,0 0.8758,0.20157 0.8758,0.20157 0,0 -0.24061,0.0888 -0.24061,0.0888 -0.001,-5.3e-4 -0.002,-0.002 -0.003,-0.002 0,0 -0.84479,-0.21441 -0.84479,-0.21441 0,0 0.2126,-0.074 0.2126,-0.074 m -0.16842,-0.7726 c 0,0 0.14597,-0.0497 0.14597,-0.0497 0.031,0.0278 0.0668,0.0513 0.11014,0.0626 0,0 0.26894,0.0684 0.26894,0.0684 0,0 -0.12832,0.0449 -0.12832,0.0449 -0.023,-0.0155 -0.0465,-0.0299 -0.0749,-0.038 0,0 -0.32183,-0.0882 -0.32183,-0.0882 m 2.04459,0.60525 c 0,0 -0.11923,0.0438 -0.11923,0.0438 -0.0273,-0.0187 -0.0578,-0.0337 -0.092,-0.0417 0,0 -0.7186,-0.16575 -0.7186,-0.16575 0,0 0.10426,-0.0364 0.10426,-0.0364 0.0267,0.0177 0.0556,0.0321 0.0888,0.039 0,0 0.73677,0.16105 0.73677,0.16105 m -0.67422,-0.84532 c 0,0 0.0438,0.0107 0.0438,0.0107 0,0 -0.0123,0.004 -0.0123,0.004 -0.009,-0.006 -0.0214,-0.009 -0.0315,-0.015 0,0 0,3e-4 0,3e-4 m -0.23686,1.75106 c 0.0326,0.0241 0.069,0.0433 0.11174,0.0508 0,0 0.96509,0.16896 0.96509,0.16896 0,0 -0.14169,0.0556 -0.14169,0.0556 0,0 -1.0624,-0.2283 -1.0624,-0.2283 0,0 0.12726,-0.0471 0.12726,-0.0471 m 5.90012,0.78757 c 0,0 -0.22082,0.10052 -0.22082,0.10052 -0.003,-5.4e-4 -0.004,-0.002 -0.006,-0.003 0,0 -1.13779,-0.24649 -1.13779,-0.24649 0,0 0.21762,-0.0914 0.21762,-0.0914 0,0 1.14699,0.24037 1.14699,0.24037 m -0.27964,-0.60525 c 0,0 0.002,-10e-4 0.002,-10e-4 0,0 0,0 0,0 0,0 0.0529,0.0123 0.0529,0.0123 0,0 -0.0549,-0.0113 -0.0549,-0.0113 m -0.75175,1.07523 c 0,0 -0.22349,0.10212 -0.22349,0.10212 -0.003,-10e-4 -0.005,-0.003 -0.008,-0.004 0,0 -1.10998,-0.29407 -1.10998,-0.29407 0,0 0.15772,-0.0663 0.15772,-0.0663 0.009,0.003 0.0155,0.009 0.0251,0.0112 0,0 1.15865,0.25105 1.15865,0.25105 m -0.98808,0.45073 c 0,0 -0.24167,0.11014 -0.24167,0.11014 0,0 -1.16077,-0.31653 -1.16077,-0.31653 0,0 0.24113,-0.10105 0.24113,-0.10105 0,0 1.16131,0.30744 1.16131,0.30744 m -2.36967,0.2005 c 0,0 0.19837,-0.0834 0.19837,-0.0834 0.0273,0.0209 0.0583,0.0374 0.093,0.0465 0,0 1.0763,0.29353 1.0763,0.29353 0,0 -0.14436,0.0658 -0.14436,0.0658 -0.005,-0.002 -0.009,-0.005 -0.0139,-0.007 0,0 -1.20941,-0.31543 -1.20941,-0.31543 m 0.45822,0.67155 c 0,0 -0.5058,0.23098 -0.5058,0.23098 0,0 -1.28536,-0.34273 -1.28536,-0.34273 0,0 0.52291,-0.21975 0.52291,-0.21975 0,0 1.26825,0.3315 1.26825,0.3315 m 1.19499,-1.94621 c -0.0192,-0.0107 -0.0369,-0.0235 -0.0588,-0.0294 0,0 -0.9159,-0.24862 -0.9159,-0.24862 0,0 0.185,-0.0727 0.185,-0.0727 0,0 1.02818,0.25076 1.02818,0.25076 0,0 -0.23848,0.1 -0.23848,0.1 m -0.78169,0.32829 c 0,0 -0.26573,0.11174 -0.26573,0.11174 -5.4e-4,0 -10e-4,-10e-4 -0.002,-10e-4 0,0 -1.03406,-0.28071 -1.03406,-0.28071 0,0 0.28338,-0.11174 0.28338,-0.11174 0.008,0.003 0.0139,0.009 0.0219,0.0112 0,0 0.99651,0.27051 0.99651,0.27051 m -1.06614,0.44805 c 0,0 -0.33738,0.14169 -0.33738,0.14169 0,0 -1.09608,-0.28819 -1.09608,-0.28819 0,0 0.36465,-0.14382 0.36465,-0.14382 0,0 5.4e-4,0 5.4e-4,0 0,0 1.06827,0.29032 1.06827,0.29032 m -4.91471,-0.0818 c 0,0 0.37587,-0.13848 0.37587,-0.13848 0,0 1.11159,0.28498 1.11159,0.28498 0,0 -0.39245,0.15452 -0.39245,0.15452 0,0 -1.09501,-0.30102 -1.09501,-0.30102 m 0.26413,0.62771 c 0,0 -0.36519,0.14382 -0.36519,0.14382 -0.007,-0.002 -0.0118,-0.007 -0.0187,-0.009 0,0 -1.13618,-0.29888 -1.13618,-0.29888 0,0 0.41811,-0.15452 0.41811,-0.15452 0.0209,0.0134 0.0417,0.0267 0.0668,0.0337 0,0 1.03516,0.28488 1.03516,0.28488 m 1.3169,0.0556 c 0.0214,0.0128 0.0417,0.0267 0.0668,0.0331 0,0 1.06988,0.28766 1.06988,0.28766 0,0 -0.43843,0.18392 -0.43843,0.18392 -0.0214,-0.0128 -0.0422,-0.0262 -0.0679,-0.0332 0,0 -1.10677,-0.28444 -1.10677,-0.28444 0,0 0.47642,-0.18704 0.47642,-0.18704 m 0.81216,-0.31973 c 0,0 0.24649,-0.0968 0.24649,-0.0968 0,0 1.12869,0.29674 1.12869,0.29674 0,0 -0.25878,0.10854 -0.25878,0.10854 -0.0128,-0.006 -0.0235,-0.015 -0.0374,-0.0182 0,0 -1.079,-0.29028 -1.079,-0.29028 m 0.19516,-1.31958 c 0.0316,0.0251 0.0668,0.046 0.10907,0.0551 0,0 0.93728,0.20158 0.93728,0.20158 0,0 -0.19301,0.0759 -0.19301,0.0759 -0.0273,-0.0192 -0.0583,-0.0342 -0.093,-0.0422 0,0 -0.95332,-0.21921 -0.95332,-0.21921 0,0 0.19298,-0.0712 0.19298,-0.0712 m 0.006,0.66621 c 0,0 -0.33685,0.1326 -0.33685,0.1326 -0.0342,-0.038 -0.0754,-0.07 -0.12885,-0.0834 0,0 -0.87152,-0.2235 -0.87152,-0.2235 0,0 0.24916,-0.092 0.24916,-0.092 0.023,0.0134 0.046,0.0267 0.0733,0.0331 0,0 1.01476,0.2332 1.01476,0.2332 m -0.31172,-1.12282 c -0.0208,-0.0123 -0.0417,-0.0257 -0.0663,-0.0315 0,0 -0.79506,-0.1989 -0.79506,-0.1989 0,0 0.0968,-0.0337 0.0968,-0.0337 0.0118,0.005 0.0208,0.0128 0.0331,0.016 0,0 0.83248,0.2112 0.83248,0.2112 0,0 -0.10102,0.0369 -0.10102,0.0369 m -0.45554,-0.93835 c -0.009,-0.003 -0.015,-0.009 -0.0235,-0.0118 0,0 -0.41758,-0.11014 -0.41758,-0.11014 0,0 0.1989,-0.0674 0.1989,-0.0674 0.0193,0.0112 0.0369,0.0241 0.0593,0.0299 0,0 0.3577,0.0984 0.3577,0.0984 0,0 -0.17482,0.061 -0.17482,0.061 m -5.78837,3.81329 c 0.0102,0.001 0.0208,0.004 0.031,0.004 0.07,0 0.13046,-0.0342 0.17965,-0.0823 0,0 0.36251,-0.13367 0.36251,-0.13367 0.0187,0.0107 0.0364,0.023 0.0583,0.0289 0,0 1.16184,0.30584 1.16184,0.30584 0,0 -0.6245,0.24594 -0.6245,0.24594 -0.0128,-0.006 -0.023,-0.0155 -0.0369,-0.0192 0,0 -1.15329,-0.34166 -1.15329,-0.34166 0,0 0.0214,-0.008 0.0214,-0.008 m 1.42597,-0.52665 c 0,0 0.46944,-0.17324 0.46944,-0.17324 0.0321,0.0321 0.0701,0.0593 0.1171,0.0717 0,0 1.01267,0.26627 1.01267,0.26627 0,0 -0.44966,0.17697 -0.44966,0.17697 -0.0321,-0.031 -0.069,-0.0572 -0.11496,-0.069 0,0 -1.03459,-0.2727 -1.03459,-0.2727 m 1.51045,0.77367 c 0,0 1.28215,0.32882 1.28215,0.32882 0,0 -0.53521,0.22457 -0.53521,0.22457 0,0 -1.27787,-0.34433 -1.27787,-0.34433 0,0 0.53093,-0.20906 0.53093,-0.20906 m 0.84906,-0.33417 c 0,0 0.44806,-0.17644 0.44806,-0.17644 0.0155,0.007 0.0283,0.0176 0.0454,0.0219 0,0 1.16933,0.30048 1.16933,0.30048 0,0 -0.42507,0.17859 -0.42507,0.17859 -0.0112,-0.005 -0.0208,-0.0128 -0.0332,-0.0161 0,0 -1.20452,-0.30843 -1.20452,-0.30843 m 2.0061,0.58172 c 0,0 1.39336,0.36358 1.39336,0.36358 0,0 -0.47586,0.21708 -0.47586,0.21708 0,0 -1.44148,-0.36037 -1.44148,-0.36037 0,0 0.52398,-0.22029 0.52398,-0.22029 m 0.8111,-0.34058 c 0,0 0.32882,-0.13795 0.32882,-0.13795 10e-4,5.4e-4 0.002,0.001 0.003,0.002 0,0 1.32118,0.35235 1.32118,0.35235 0,0 -0.30477,0.13902 -0.30477,0.13902 -0.004,-0.002 -0.007,-0.004 -0.0118,-0.006 0,0 -1.33643,-0.34942 -1.33643,-0.34942 m 1.74945,0.75977 c 0,0 1.3832,0.3748 1.3832,0.3748 0,0 -0.43309,0.21066 -0.43309,0.21066 0,0 -1.41367,-0.37373 -1.41367,-0.37373 0,0 0.46356,-0.21173 0.46356,-0.21173 m 0.76137,-0.34754 c 0,0 0.5042,-0.22991 0.5042,-0.22991 0,0 1.35914,0.34861 1.35914,0.34861 0,0 -0.51008,0.24808 -0.51008,0.24808 0,0 -1.35326,-0.36678 -1.35326,-0.36678 m 1.27894,-0.58333 c 0,0 4.50462,-2.05475 4.50462,-2.05475 0,0 1.14474,0.29461 1.14474,0.29461 0,0 -4.32177,2.10073 -4.32177,2.10073 0,0 -1.32759,-0.34059 -1.32759,-0.34059 m 5.54028,-3.11447 c -0.0176,-0.008 -0.0337,-0.0187 -0.0535,-0.0225 0,0 -0.94477,-0.19141 -0.94477,-0.19141 0,0 0.14329,-0.0604 0.14329,-0.0604 0.0257,0.0171 0.054,0.0321 0.0861,0.039 0,0 0.85227,0.19676 0.85227,0.19676 0,0 -0.0834,0.0385 -0.0834,0.0385 m -0.8111,0.36946 c 0,0 -0.0968,0.0444 -0.0968,0.0444 -0.0235,-0.0139 -0.0471,-0.0273 -0.0749,-0.0337 0,0 -0.92445,-0.21226 -0.92445,-0.21226 0,0 0.0497,-0.0209 0.0497,-0.0209 0.0166,0.007 0.031,0.0171 0.0486,0.0209 0,0 0.99785,0.20156 0.99785,0.20156 m -0.57049,-1.00251 c -0.0225,-0.0123 -0.0444,-0.0257 -0.0706,-0.0316 0,0 -0.81484,-0.18125 -0.81484,-0.18125 0,0 0.16468,-0.0647 0.16468,-0.0647 5.3e-4,0 5.3e-4,5.4e-4 5.3e-4,5.4e-4 0,0 0.88007,0.20959 0.88007,0.20959 0,0 -0.15984,0.0674 -0.15984,0.0674 m -0.82875,0.34807 c 0,0 -0.0754,0.0315 -0.0754,0.0315 -0.0171,-0.007 -0.0321,-0.0182 -0.0508,-0.0224 0,0 -0.88274,-0.19462 -0.88274,-0.19462 0,0 0.10372,-0.0412 0.10372,-0.0412 0.0294,0.0225 0.0631,0.0396 0.10159,0.0481 0,0 0.80363,0.17862 0.80363,0.17862 m -0.91215,0.38336 c 0,0 -0.0797,0.0337 -0.0797,0.0337 0,0 -0.97685,-0.22456 -0.97685,-0.22456 0,0 0.0893,-0.0353 0.0893,-0.0353 0.0192,0.01 0.0369,0.0214 0.0588,0.0262 0,0 0.90845,0.19996 0.90845,0.19996 m -0.92391,0.38817 c 0,0 -0.10854,0.0455 -0.10854,0.0455 -0.0123,-0.005 -0.0225,-0.0139 -0.0358,-0.0171 0,0 -0.94583,-0.23098 -0.94583,-0.23098 0,0 0.10533,-0.0412 0.10533,-0.0412 0.0235,0.0139 0.0471,0.0278 0.0754,0.0342 0,0 0.90944,0.20958 0.90944,0.20958 m -0.41063,-1.04421 c -0.0144,-0.006 -0.0273,-0.016 -0.0433,-0.0198 0,0 -0.84211,-0.20103 -0.84211,-0.20103 0,0 0.0636,-0.0235 0.0636,-0.0235 0,0 0.93621,0.19943 0.93621,0.19943 0,0 -0.1144,0.0449 -0.1144,0.0449 m -0.85388,0.33631 c 0,0 -0.0674,0.0262 -0.0674,0.0262 -0.0219,-0.0112 -0.0428,-0.0235 -0.0679,-0.0283 0,0 -0.91268,-0.18019 -0.91268,-0.18019 0,0 0.14703,-0.0545 0.14703,-0.0545 0.0278,0.0198 0.0593,0.0353 0.0946,0.0439 0,0 0.80635,0.19289 0.80635,0.19289 m -0.96401,0.37961 c 0,0 -0.0802,0.0316 -0.0802,0.0316 -0.0112,-0.004 -0.0208,-0.0107 -0.0326,-0.0128 0,0 -1.04635,-0.18286 -1.04635,-0.18286 0,0 0.13527,-0.0503 0.13527,-0.0503 0.0182,0.009 0.0353,0.0192 0.0556,0.023 0,0 0.96828,0.19136 0.96828,0.19136 m -0.32936,-1.04047 c -0.0342,-0.0321 -0.0738,-0.0588 -0.12297,-0.0695 0,0 -0.63252,-0.13794 -0.63252,-0.13794 0,0 0.1727,-0.0604 0.1727,-0.0604 0.002,5.3e-4 0.004,0.003 0.006,0.003 0,0 0.77421,0.19194 0.77421,0.19194 0,0 -0.19742,0.0729 -0.19742,0.0729 m -0.60846,-0.825 c -0.0289,-0.0225 -0.062,-0.0406 -0.1,-0.0497 0,0 -0.26894,-0.0663 -0.26894,-0.0663 0,0 0.0818,-0.0278 0.0818,-0.0278 0.0326,0.0321 0.0701,0.0594 0.11763,0.0717 0,0 0.21654,0.0561 0.21654,0.0561 0,0 -0.047,0.016 -0.047,0.016 m -6.84381,1.51633 c 0,0 -8.70929,2.95621 -8.70929,2.95621 0,0 8.93599,-20.90412 8.93599,-20.90412 0,0 6.50804,15.63224 6.50804,15.63224 0,0 -6.73474,2.31567 -6.73474,2.31567 m -3.00914,1.93017 c 0,0 -0.4887,0.1711 -0.4887,0.1711 -0.0123,-0.005 -0.0219,-0.0139 -0.0348,-0.0182 0,0 -0.48174,-0.13741 -0.48174,-0.13741 0,0 0.532,-0.18286 0.532,-0.18286 0.0342,0.0369 0.0748,0.0674 0.12672,0.0802 0,0 0.34652,0.0872 0.34652,0.0872 m -1.35059,0.47212 c 0,0 -0.50901,0.17804 -0.50901,0.17804 -0.007,-0.003 -0.0123,-0.007 -0.0192,-0.009 0,0 -0.54162,-0.13901 -0.54162,-0.13901 0,0 0.55285,-0.18981 0.55285,-0.18981 0.0177,0.01 0.0337,0.0219 0.054,0.0278 0,0 0.46298,0.13198 0.46298,0.13198 m -1.92803,0.32508 c 0.0315,0.0294 0.0684,0.0545 0.11335,0.0658 0,0 0.40261,0.1032 0.40261,0.1032 0,0 -1.01802,0.35609 -1.01802,0.35609 -0.002,5.3e-4 -0.003,0.003 -0.005,0.003 -0.21922,-0.0567 -0.41545,-0.10694 -0.58921,-0.15185 0,0 1.09627,-0.37624 1.09627,-0.37624 m 1.09394,0.53307 c 0.0235,0.015 0.0476,0.0289 0.0759,0.0364 0,0 1.05491,0.26359 1.05491,0.26359 0,0 -0.6368,0.23526 -0.6368,0.23526 -0.41651,-0.10747 -0.80789,-0.20799 -1.16505,-0.29996 0,0 0.67104,-0.23529 0.67104,-0.23529 m 0.89077,-0.31172 c 0,0 0.56515,-0.19783 0.56515,-0.19783 0.0182,0.0107 0.0342,0.0235 0.0551,0.0294 0,0 0.94958,0.28873 0.94958,0.28873 0,0 -0.44859,0.16574 -0.44859,0.16574 -0.009,-0.003 -0.0155,-0.01 -0.0246,-0.0118 0,0 -1.09664,-0.27424 -1.09664,-0.27424 m 1.57621,0.68759 c 0.009,0.004 0.016,0.0107 0.0257,0.0139 0,0 1.19713,0.35449 1.19713,0.35449 0,0 -0.94156,0.37053 -0.94156,0.37053 -0.46623,-0.11977 -0.91589,-0.23579 -1.34524,-0.34647 0,0 1.06397,-0.39245 1.06397,-0.39245 m 2.42528,0.46945 c 0.004,10e-4 0.007,0.004 0.0107,0.005 0,0 1.29552,0.34914 1.29552,0.34914 0,0 -1.18591,0.49832 -1.18591,0.49832 -0.46944,-0.12084 -0.9314,-0.23953 -1.38213,-0.35556 0,0 1.26182,-0.4969 1.26182,-0.4969 m 2.87066,0.27696 c 0,0 1.48318,0.37106 1.48318,0.37106 0,0 -1.81307,0.82714 -1.81307,0.82714 -0.52398,-0.13474 -1.04689,-0.26948 -1.56446,-0.40261 0,0 1.89435,-0.79559 1.89435,-0.79559 m 1.32225,1.03245 c 0.002,5.4e-4 0.003,0.002 0.005,0.002 0,0 1.49976,0.39085 1.49976,0.39085 0,0 -0.78651,0.38229 -0.78651,0.38229 -0.51061,-0.13153 -1.02764,-0.26413 -1.54627,-0.3978 0,0 0.82802,-0.37734 0.82802,-0.37734 m 0.76832,-0.35074 c 0,0 0.58494,-0.26681 0.58494,-0.26681 0,0 1.44415,0.38229 1.44415,0.38229 0,0 -0.55392,0.26895 -0.55392,0.26895 0,0 -1.47517,-0.38443 -1.47517,-0.38443 m 13.37057,-5.39753 c 0,0 -1.36074,0.66139 -1.36074,0.66139 -0.0134,-0.005 -0.0241,-0.0139 -0.038,-0.0176 0,0 -1.02604,-0.239 -1.02604,-0.239 0,0 1.37144,-0.62557 1.37144,-0.62557 0.35983,0.0759 0.71325,0.14971 1.0533,0.22082 0,0 4e-5,-4e-5 4e-5,-4e-5 m -2.82842,-0.59135 c 0.30316,0.0636 0.59991,0.12565 0.8913,0.1866 0,0 -1.1736,0.53521 -1.1736,0.53521 -0.0203,-0.0107 -0.039,-0.023 -0.0626,-0.0283 0,0 -0.84158,-0.19408 -0.84158,-0.19408 0,0 1.1827,-0.49672 1.1827,-0.49672 0.002,-5.3e-4 0.002,-0.002 0.004,-0.003 0,0 -2.2e-4,2.9e-4 -2.2e-4,2.9e-4 m -1.78099,-0.37213 c 0.29193,0.0609 0.57851,0.12084 0.86082,0.17965 0,0 -0.64642,0.27161 -0.64642,0.27161 -0.0283,-0.0208 -0.0609,-0.0374 -0.0973,-0.046 0,0 -0.71486,-0.17002 -0.71486,-0.17002 0,0 0.59776,-0.23524 0.59776,-0.23524 m -1.7794,-0.3716 c 0.2791,0.0583 0.555,0.11603 0.82607,0.1727 0,0 -0.84692,0.33364 -0.84692,0.33364 -0.0294,-0.0209 -0.0625,-0.0374 -0.10052,-0.0455 0,0 -0.71592,-0.15185 -0.71592,-0.15185 0,0 0.83729,-0.30899 0.83729,-0.30899 m -1.05491,0.91269 c -0.0241,-0.0144 -0.0492,-0.0278 -0.0781,-0.0342 0,0 -0.79131,-0.16842 -0.79131,-0.16842 0,0 0.16735,-0.062 0.16735,-0.062 0.0182,0.009 0.0342,0.0192 0.0545,0.0235 0,0 0.81858,0.17377 0.81858,0.17377 0,0 -0.17102,0.0674 -0.17102,0.0674 m -0.66352,-1.27199 c 0.24701,0.0513 0.49189,0.10266 0.73357,0.15345 0,0 -1.01642,0.37534 -1.01642,0.37534 -0.009,-0.003 -0.015,-0.009 -0.0235,-0.0102 0,0 -0.72235,-0.15826 -0.72235,-0.15826 0,0 1.0287,-0.36033 1.0287,-0.36033 m -1.53345,-0.25504 c 0.0786,-0.0273 0.1588,-0.0326 0.23793,-0.0155 0,0 0.28231,0.0588 0.28231,0.0588 0,0 -0.15452,0.054 -0.15452,0.054 -0.0112,-0.004 -0.0203,-0.0123 -0.0326,-0.015 0,0 -0.34058,-0.0802 -0.34058,-0.0802 0,0 0.007,-0.002 0.007,-0.002 m -0.43522,0.9437 c 0.0187,0.009 0.0353,0.0203 0.0567,0.0246 0,0 0.70791,0.15506 0.70791,0.15506 0,0 -0.20211,0.0743 -0.20211,0.0743 -0.0224,-0.0134 -0.0449,-0.0273 -0.0716,-0.0342 0,0 -0.65658,-0.16254 -0.65658,-0.16254 0,0 0.16568,-0.0572 0.16568,-0.0572 m -0.39566,-0.586 c 0,0 0.27108,0.0636 0.27108,0.0636 0,0 -0.0642,0.0225 -0.0642,0.0225 -0.0262,-0.0187 -0.0556,-0.0348 -0.0888,-0.0433 0,0 -0.26519,-0.0684 -0.26519,-0.0684 0,0 0.0519,-0.0176 0.0519,-0.0176 0.0278,0.0198 0.0599,0.0347 0.0952,0.0433 0,0 10e-6,-1e-4 10e-6,-1e-4 m -26.2717,-17.39933 c 0,0 18.96379,0.29567 18.96379,0.29567 0.13206,-0.0107 0.3454,0.16949 0.43148,0.38229 0,0 6.76361,16.11986 6.76361,16.11986 0,0 -0.19141,0.0652 -0.19141,0.0652 0,0 -6.60268,-15.85787 -6.60268,-15.85787 -0.0417,-0.1 -0.14489,-0.14276 -0.24809,-0.16468 0,0 -17.74473,0.10052 -17.74473,0.10052 -0.0882,5.3e-4 -0.17056,0.0444 -0.22028,0.11763 -0.0492,0.0732 -0.0593,0.16628 -0.0267,0.24809 0,0 8.37192,21.14578 8.37192,21.14578 0,0 -0.51864,0.17591 -0.51864,0.17591 -0.0171,0.005 -0.0326,0.0139 -0.0476,0.0225 0,0 -8.92691,-22.30763 -8.92691,-22.30763 -0.0845,-0.21013 -0.0471,-0.32776 -0.004,-0.34326 0,0 2.4e-4,-10e-6 2.4e-4,-10e-6 m 0.55018,23.47161 c 0.56461,-1.73769 2.59851,-8.0356 3.28289,-10.15505 0,0 0.15025,0.37588 0.15025,0.37588 -0.0193,0.0241 -0.0358,0.0508 -0.046,0.0818 0,0 -2.9006,8.99855 -2.9006,8.99855 -0.003,0.009 -0.001,0.0171 -0.003,0.0257 -0.004,0.0171 -0.005,0.0342 -0.006,0.0519 0,0.0187 10e-4,0.0364 0.005,0.0545 0.002,0.008 -5.3e-4,0.0166 0.002,0.0246 0.002,0.005 0.007,0.007 0.009,0.0123 0.0166,0.0476 0.0439,0.0898 0.0845,0.12137 0.006,0.005 0.0139,0.007 0.0208,0.0118 0.0193,0.0123 0.038,0.0267 0.061,0.0342 0.0273,0.009 0.0545,0.0134 0.0818,0.0134 0.0246,0 0.0497,-0.003 0.0743,-0.0107 0,0 5.72314,-1.65963 5.72314,-1.65963 0,0 0.031,0.077 0.031,0.077 -1.10677,0.32562 -5.83863,1.72165 -6.57006,1.94247 0,0 -2e-5,-9e-5 -2e-5,-9e-5 m 8.57937,0.81538 c 0,0 -0.11015,0.006 -0.11015,0.006 -0.0914,-0.007 -0.27215,-0.13527 -0.37534,-0.39406 0,0 -9.19745,-22.98132 -9.19745,-22.98132 -0.0503,-0.12564 -0.0577,-0.23311 -0.0214,-0.30209 0.0166,-0.0315 0.0503,-0.0519 0.0818,-0.0727 0,0 9.02796,22.55786 9.02796,22.55786 -0.0112,0.16254 0.0754,0.38229 0.28926,0.72288 0,0 0.0904,0.22616 0.0904,0.22616 0.0283,0.0711 0.0877,0.11335 0.15345,0.13955 0.0224,0.0321 0.0449,0.0642 0.069,0.0979 -0.002,-0.001 -0.005,0 -0.007,0 0,0 -5.3e-4,-1.8e-4 -5.3e-4,-1.8e-4 m 1.22065,0.0305 c -0.36037,0.15292 -0.44859,0.10908 -0.44912,0.10854 -0.0241,-0.0348 -0.0668,-0.093 -0.12137,-0.16682 -0.21654,-0.29193 -0.36679,-0.50847 -0.47426,-0.67475 0,0 -0.16147,-0.40368 -0.16147,-0.40368 0.25397,0.0684 1.15222,0.31064 2.47019,0.66567 -0.49297,0.18072 -1.13671,0.41758 -1.26397,0.47104 0,0 0,0 0,0 m 32.60277,-2.05154 c -3.53793,2.37876 -9.4589,6.36101 -9.72998,6.55028 -0.28766,0.20051 -0.77421,0.0829 -0.93354,0.0449 -0.24702,-0.0615 -18.18798,-4.89708 -22.24615,-5.99102 0,0 0.36679,-0.12618 0.36679,-0.12618 1.43132,0.36839 21.24684,5.4681 21.47675,5.52424 0.11388,0.0273 0.34807,0.084 0.61541,0.084 0.24541,0 0.51863,-0.0476 0.75068,-0.21013 0.14703,-0.10266 1.99486,-1.30728 4.15548,-2.71347 0.0155,-0.006 0.0337,-0.005 0.0476,-0.0144 0,0 1.29231,-0.85762 1.29231,-0.85762 1.20996,-0.78704 2.43009,-1.58049 3.43902,-2.236 1.77244,-1.15276 2.48355,-1.61525 2.56536,-1.66872 0.24007,0.0481 0.39619,0.0781 0.4657,0.0893 -0.25878,0.17537 -1.11747,0.75281 -2.26541,1.52488 0,0 -2e-5,-6e-5 -2e-5,-6e-5"
+           id="path1550"
+           style="fill:#d4ff2a;stroke-width:0.75614202"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 949.30717,533.3585 c 0,0 -0.38045,-0.0696 -0.38045,-0.0696 0,0 10e-4,-0.0488 10e-4,-0.0488 0.002,-0.071 -0.0361,-0.13635 -0.0979,-0.171 0,0 -0.97665,-0.54381 -0.97665,-0.54381 -0.0177,-0.01 -0.0366,-0.0165 -0.0556,-0.0204 0,0 -11.68068,-2.31552 -11.68068,-2.31552 -0.0349,-0.007 -0.0705,-0.004 -0.10363,0.008 0,0 -0.0689,0.0255 -0.0689,0.0255 0,0 -0.2035,-0.0135 -0.2035,-0.0135 -0.0317,-0.001 -0.0619,0.004 -0.0905,0.0166 -0.11881,0.0533 -0.33133,0.21365 -0.37377,0.47793 -0.0496,0.30954 0.11907,0.52418 0.13837,0.54753 0.016,0.0195 0.0358,0.0356 0.0577,0.0471 0,0 0.161,0.0851 0.161,0.0851 -0.0131,0.0379 -0.0179,0.0778 -0.006,0.11742 0.0206,0.0658 0.0748,0.11511 0.14202,0.12966 0,0 3.11236,0.66848 3.11236,0.66848 0.0118,0.003 0.024,0.004 0.0358,0.004 0.0195,4.6e-4 0.039,-0.002 0.0574,-0.007 0.038,-0.0109 0.0867,-0.0354 0.13526,-0.0717 0,0 8.33989,1.75353 8.33989,1.75353 0.0114,0.003 0.0232,0.004 0.0346,0.004 0.0118,2.8e-4 0.0241,-5.4e-4 0.0356,-0.003 0,0 1.23841,-0.20507 1.23841,-0.20507 0.0617,-0.0104 0.11035,-0.0505 0.13715,-0.10329 0,0 0.34092,0.0625 0.34092,0.0625 0.0103,0.002 0.0205,0.003 0.0305,0.003 0.0919,0.002 0.17476,-0.0631 0.19182,-0.15622 0.0196,-0.10374 -0.0487,-0.20305 -0.15245,-0.22226 0,0 2.3e-4,8.2e-4 2.3e-4,8.2e-4 m -13.29851,-2.17617 c -0.0181,-0.0115 -0.0362,-0.0199 -0.0563,-0.0246 -0.008,-0.0132 -0.0205,-0.0222 -0.0313,-0.0332 0,0 1.97891,0.39927 1.97891,0.39927 -4e-5,0.0191 -1.4e-4,0.0378 2.3e-4,0.0561 0,0 -1.89154,-0.39757 -1.89154,-0.39757 m 1.94518,-0.0363 c 0,0 -1.70386,-0.34398 -1.70386,-0.34398 0.003,-0.0465 -0.0115,-0.0942 -0.0435,-0.1327 -0.0672,-0.0817 -0.18755,-0.0926 -0.26888,-0.0258 0,0 -0.16268,0.13438 -0.16268,0.13438 -0.0568,0.0468 -0.0815,0.12215 -0.0633,0.19357 0.003,0.0123 0.0129,0.0201 0.0184,0.0313 0,0 -0.0362,-0.0192 -0.0362,-0.0192 -0.0224,-0.0394 -0.0564,-0.11964 -0.0403,-0.21927 0.0134,-0.0852 0.0789,-0.14206 0.11963,-0.17011 0,0 0.18673,0.0127 0.18673,0.0127 0.0286,6.4e-4 0.0543,-0.003 0.0793,-0.0119 0,0 0.0566,-0.0212 0.0566,-0.0212 0,0 1.935,0.38373 1.935,0.38373 -0.0295,0.0547 -0.0547,0.11743 -0.0769,0.18829 0,0 -4e-5,1.9e-4 -4e-5,1.9e-4 m 0.33189,0.51502 c -10e-4,-0.0202 -0.003,-0.0382 -0.004,-0.0604 0,0 0.45246,0.0915 0.45246,0.0915 0.0396,0.005 0.18186,0.0417 0.19262,0.10374 0,0 -0.64108,-0.13484 -0.64108,-0.13484 m 9.01982,1.45298 c -0.0294,0.14818 -0.0283,0.31462 -0.0213,0.4396 0,0 -7.97791,-1.67752 -7.97791,-1.67752 0.003,-0.0259 0.006,-0.0518 0.006,-0.0804 -0.005,-0.29059 -0.28103,-0.45352 -0.51859,-0.47968 0,0 -0.46538,-0.0941 -0.46538,-0.0941 0.0313,-0.0829 0.0721,-0.14756 0.10127,-0.18505 0,0 8.99002,1.78169 8.99002,1.78169 -0.0454,0.0814 -0.09,0.17767 -0.11377,0.29544 0,0 -3.4e-4,2e-5 -3.4e-4,2e-5 m 1.23632,0.31017 c 0,0 -0.87441,0.14486 -0.87441,0.14486 -0.007,-0.10399 -0.0123,-0.2564 0.0123,-0.38064 0.0225,-0.11322 0.0776,-0.20277 0.11747,-0.25757 0,0 0.74643,0.41553 0.74643,0.41553 0,0 -0.002,0.0778 -0.002,0.0778"
+           id="path1552"
+           style="fill:#d4ff2a;stroke-width:0.75614202"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         id="media_player.yamaha_receiver"
+         d="m 1136.7305,366.51919 c -1.1936,7e-5 -2.3383,0.47437 -3.1821,1.31853 -0.8439,0.84415 -1.3177,1.98898 -1.3174,3.18257 -4e-4,1.19361 0.4735,2.33847 1.3173,3.18264 0.8439,0.84417 1.9886,1.31849 3.1822,1.31856 1.1937,7e-5 2.3385,-0.47417 3.1824,-1.31836 0.844,-0.84419 1.3179,-1.98914 1.3176,-3.18284 3e-4,-1.19369 -0.4736,-2.3386 -1.3176,-3.18277 -0.844,-0.84417 -1.9888,-1.3184 -3.1824,-1.31833 m 0,12.0012 c -1.9891,-5e-5 -3.8967,-0.79028 -5.3031,-2.19683 -1.4064,-1.40656 -2.1964,-3.31421 -2.1963,-5.30327 -10e-5,-1.98903 0.79,-3.89663 2.1964,-5.30314 1.4064,-1.40651 3.3139,-2.19671 5.303,-2.19676 1.989,2e-5 3.8966,0.79021 5.303,2.19672 1.4064,1.40652 2.1965,3.31413 2.1964,5.30318 10e-5,1.98908 -0.7899,3.89675 -2.1963,5.3033 -1.4065,1.40656 -3.3141,2.19678 -5.3031,2.1968 m 0,-24.0023 c 1.6564,-10e-5 2.9994,1.34244 3,2.9989 0,0.79644 -0.3143,1.56069 -0.8771,2.12428 -0.5627,0.5636 -1.3265,0.88027 -2.1229,0.88022 -1.665,0 -3.0001,-1.3492 -3.0001,-3.0045 0,-1.661 1.3351,-2.9989 3.0001,-2.9989 m 7.4994,-2.9988 c 0,0 -14.9988,0 -14.9988,0 -1.6649,0 -3,1.3378 -3,2.9988 0,0 0,24.0023 0,24.0023 5e-4,1.65649 1.3436,2.99903 3,2.9989 0,0 14.9988,0 14.9988,0 1.6565,1.1e-4 2.9995,-1.34243 3,-2.9989 0,0 0,-24.0023 0,-24.0023 0,-1.661 -1.3498,-2.9988 -3,-2.9988 0,0 0,0 0,0"
+         style="fill:#d4ff2a"
+         inkscape:connector-curvature="0" />
+      <path
+         id="sensor.device_athos"
+         d="m 1105.7305,351.52039 c 0,0 12,0 12,0 0.7957,0 1.5587,0.3161 2.1213,0.8787 0.5626,0.5626 0.8787,1.3257 0.8787,2.1213 0,0 0,24 0,24 0,0.7957 -0.3161,1.5587 -0.8787,2.1214 -0.5626,0.5626 -1.3256,0.8786 -2.1213,0.8786 0,0 -12,0 -12,0 -0.7956,0 -1.5587,-0.316 -2.1213,-0.8786 -0.5626,-0.5627 -0.8787,-1.3257 -0.8787,-2.1214 0,0 0,-24 0,-24 0,-0.7956 0.3161,-1.5587 0.8787,-2.1213 0.5626,-0.5626 1.3257,-0.8787 2.1213,-0.8787 m 0,3 c 0,0 0,3 0,3 0,0 12,0 12,0 0,0 0,-3 0,-3 0,0 -12,0 -12,0 m 12,6 c 0,0 -12,0 -12,0 0,0 0,3 0,3 0,0 12,0 12,0 0,0 0,-3 0,-3 m 0,15 c 0,0 -3,0 -3,0 0,0 0,3 0,3 0,0 3,0 3,0 0,0 0,-3 0,-3"
+         style="fill:#d4ff2a"
+         inkscape:connector-curvature="0"
+         inkscape:label="sensor.device_athos" />
+      <g
+         id="sensor.device_echo_dot_family_room"
+         inkscape:label="sensor.device_echo_dot_family_room">
+        <path
+           id="path8542-5"
+           d="m 1119.4299,332.9105 c 1.1442,0 2.423,-0.28692 2.423,-0.83869 0,-0.55177 -1.2788,-0.88284 -2.423,-0.88284 -1.1442,0 -2.423,0.28692 -2.423,0.83869 0,0.55177 1.3012,0.88284 2.423,0.88284 z m 0,-1.30218 c 1.2788,0 1.9518,0.33106 1.9518,0.41934 -0.045,0.13243 -0.7179,0.41935 -1.9518,0.41935 -1.2788,0 -1.9519,-0.33106 -1.9519,-0.41935 0.022,-0.0883 0.6731,-0.41934 1.9519,-0.41934 z"
+           inkscape:connector-curvature="0"
+           style="fill:#d4ff2a;stroke-width:0.22252241" />
+        <path
+           id="path8544-1"
+           d="m 1129.0097,332.9105 c 1.1442,0 2.423,-0.28692 2.423,-0.83869 0,-0.55177 -1.2788,-0.88284 -2.423,-0.88284 -1.1442,0 -2.423,0.28692 -2.423,0.83869 0,0.55177 1.2788,0.88284 2.423,0.88284 z m 0,-1.30218 c 1.2788,0 1.9518,0.33106 1.9518,0.41934 -0.045,0.13243 -0.7179,0.41935 -1.9518,0.41935 -1.2788,0 -1.9519,-0.33106 -1.9967,-0.41935 0.045,-0.0883 0.7179,-0.41934 1.9967,-0.41934 z"
+           inkscape:connector-curvature="0"
+           style="fill:#d4ff2a;stroke-width:0.22252241" />
+        <path
+           style="fill:#d4ff2a;stroke-width:0.22252241"
+           inkscape:connector-curvature="0"
+           d="m 1124.3207,328.54048 c -1.0544,0 -9.9612,0.0883 -9.9612,3.53133 v 5.8929 c 0,3.44304 8.9516,3.53132 9.9388,3.53132 0.9871,0 9.9388,-0.0883 9.9388,-3.53132 v -5.93705 c 0.022,-3.3989 -8.9292,-3.48718 -9.9164,-3.48718 z m 8.6151,9.35802 c 0,1.01525 -3.5447,2.14086 -8.5702,2.14086 -5.0255,0 -8.5702,-1.12561 -8.5702,-2.14086 v -3.90654 c 1.3685,0.79455 4.2178,1.5891 8.5702,1.5891 3.971,0 6.7306,-0.55177 8.5702,-1.67738 z m 0,-4.50245 c -1.7948,1.2139 -4.5543,1.76567 -8.5702,1.76567 -4.5543,0 -7.4485,-0.88284 -8.5702,-1.67738 v -0.59592 c 1.2339,1.16976 4.9806,1.76567 8.5702,1.76567 3.5896,0 7.3363,-0.59591 8.5702,-1.76567 z m -8.5253,0.83869 c -5.0255,0 -8.5703,-1.16975 -8.5703,-2.18501 0,-1.01525 3.4999,-2.185 8.5703,-2.185 5.0703,0 8.5702,1.14768 8.5702,2.16293 0,1.01526 -3.5448,2.20708 -8.5702,2.20708 z"
+           id="path8548-6" />
+      </g>
+      <rect
+         style="fill:#d4ff2a"
+         id="sensor.device_tcl_tv"
+         width="108.12841"
+         height="6.6669998"
+         x="974.039"
+         y="335.48001"
+         inkscape:label="sensor.device_tcl_tv" />
+    </g>
+  </g>
+  <g
+     inkscape:label="Main"
+     id="main">
+    <g
+       id="main_structure"
+       inkscape:label="Structure">
+      <path
+         inkscape:label="Backdrop"
+         style="fill:#3d3b3f"
+         inkscape:connector-curvature="0"
+         d="m 1500.9971,27.82169 c 50.6684,0.0618 101.3492,-0.13601 152.0175,0.0865 13.8974,12.19107 26.6572,26.18731 39.8869,39.3057 l 0.9767,0.1731 c 0,328.05857 0,656.12951 0,984.18811 -149.1985,0 -298.397,0 -447.5831,0 0,-158.2615 0,-316.5228 0,-474.78423 -36.2765,0 -72.5406,-0.0124 -108.8047,0 0,41.20973 0,82.41953 0,123.64173 -89.4424,0 -178.87251,0 -268.30258,0 0,13.9963 0,28.0173 0,42.0382 -73.36901,0 -146.72565,0 -220.08229,0 0,-224.61993 0,-449.22748 0,-673.8474 270.34266,-0.0371 540.69767,0.0742 811.04037,-0.0494 13.8602,-12.26526 26.6571,-26.21205 39.8744,-39.3428 l 0.9768,-0.1731 z"
+         id="structure_main_backdrop" />
+      <g
+         inkscape:label="Support"
+         id="main_structure_support">
+        <g
+           inkscape:label="Shelves"
+           id="main_structure_support_shelves">
+          <path
+             inkscape:connector-curvature="0"
+             id="path5339"
+             d="M 931.02393,320.0127 H 1085.7035 V 250.77516"
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5341"
+             d="M 1109.4211,323.40092 H 931.02393"
+             style="fill:none;stroke:#464646;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6, 1;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 834.53331,472.01814 H 782.82613"
+             id="path5054"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 656.13617,485.00429 H 776.04969"
+             id="path5048"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6, 1;stroke-dashoffset:0;stroke-opacity:1"
+             d="M 655.98885,481.46875 H 776.04969"
+             id="path5052"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 893.125,693.79167 v -151.875"
+             id="path5042"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6, 1;stroke-dashoffset:0;stroke-opacity:1"
+             d="M 889.77603,693.52713 V 538.99483"
+             id="path5044"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 1264.4792,505.14583 v 64.58334"
+             id="path5034"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6, 1;stroke-dashoffset:0;stroke-opacity:1"
+             d="m 1267.9167,505.35417 v 64.47916"
+             id="path5036"
+             inkscape:connector-curvature="0" />
+          <path
+             inkscape:label="path5018"
+             inkscape:connector-curvature="0"
+             id="path5018"
+             d="m 1381.25,395.45833 h 75"
+             style="fill:none;stroke:#464646;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:label="path5016"
+             inkscape:connector-curvature="0"
+             id="path5016"
+             d="m 1282.3676,433.2971 v 64.67081"
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        </g>
+        <path
+           style="fill:none;stroke:#464646;stroke-width:0.99482435;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:5.96894618, 0.99482437;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 1381.2153,454.21568 h 98.8476"
+           id="path5014"
+           inkscape:connector-curvature="0"
+           inkscape:label="Laundry Cabinets" />
+        <path
+           style="fill:none;stroke:#464646;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6, 1;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 1463.1218,405.7494 h 182.3746 l 21.0659,-21.06589 V 350.654 h 19.8874 m -0.2947,-75.42473 h -20.0347 v -33.8822"
+           id="path5012"
+           inkscape:connector-curvature="0"
+           inkscape:label="Kitchen Cabinets" />
+        <path
+           style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+           d="m 1646.0977,364.33571 -0.1481,-123.22916 40.0777,-0.10417 v 184.14239 h -156.9085 l 0.1665,-39.66536 96.058,-0.10276 z"
+           id="rect4903"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc"
+           inkscape:label="Kitchen Counter" />
+        <rect
+           style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5010"
+           width="107.53915"
+           height="58.630936"
+           x="1469.8982"
+           y="251.06979"
+           inkscape:label="Kitchen Island" />
+        <g
+           id="g4947"
+           inkscape:label="Kitchen Sink">
+          <rect
+             ry="4.5667315"
+             y="315.00403"
+             x="1650.947"
+             height="25.927248"
+             width="31.819805"
+             id="rect4906-5"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             ry="4.5667315"
+             y="285.54126"
+             x="1650.947"
+             height="25.927248"
+             width="31.819805"
+             id="rect4906"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             y="281.8584"
+             x="1649.032"
+             height="62.078072"
+             width="37.019764"
+             id="rect4923"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+          <circle
+             r="2.6516504"
+             cy="297.62097"
+             cx="1667.4463"
+             id="path4925"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+          <circle
+             r="2.6516504"
+             cy="328.65213"
+             cx="1667.4467"
+             id="path4925-3"
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           inkscape:label="Bathtub"
+           id="g5078">
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 707.5,349.83333 V 453.375"
+             id="path5069"
+             inkscape:connector-curvature="0" />
+          <rect
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect5071"
+             width="42.916668"
+             height="94.583336"
+             x="660.62494"
+             y="355.45837"
+             ry="7.9166665" />
+          <circle
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5073"
+             cx="681.77081"
+             cy="362.02084"
+             r="2.8125" />
+        </g>
+        <g
+           inkscape:label="Toilet"
+           id="g5219">
+          <rect
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect5175"
+             width="38.333332"
+             height="10.625"
+             x="714.16669"
+             y="354.10416"
+             rx="2.06545"
+             ry="2.06545" />
+          <ellipse
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5177"
+             cx="733.59375"
+             cy="381.13541"
+             rx="13.072917"
+             ry="16.40625" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 723.33333,364.83333 v 6.14584"
+             id="path5196"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 743.85416,364.83333 v 6.14584"
+             id="path5196-5"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           inkscape:label="Bathroom Counter"
+           inkscape:connector-curvature="0"
+           id="path5080"
+           d="m 759.10859,350.06474 v 35.06071 H 834.386 m -75.27741,-32.26174 h 75.71935"
+           style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <g
+           inkscape:label="Bathroom Sink"
+           id="g5097">
+          <ellipse
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5082"
+             cx="807.13293"
+             cy="368.55264"
+             rx="18.41424"
+             ry="15.541617" />
+          <ellipse
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5084"
+             cx="807.28021"
+             cy="370.61502"
+             rx="16.499159"
+             ry="11.416828" />
+          <circle
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5086"
+             cx="807.133"
+             cy="367.44778"
+             r="1.620453" />
+          <rect
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect5088"
+             width="13.700193"
+             height="3.3882201"
+             x="800.20917"
+             y="354.48413"
+             rx="0.29462782"
+             ry="0.29462782" />
+          <rect
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect5090"
+             width="4.0104165"
+             height="9.140625"
+             x="805.10419"
+             y="355.04166"
+             rx="0.29462799"
+             ry="0.29462799" />
+        </g>
+        <g
+           inkscape:label="Bathroom Sink"
+           id="g5361">
+          <ellipse
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5082-0-5"
+             cx="956.82025"
+             cy="96.11528"
+             rx="18.41424"
+             ry="15.541617" />
+          <ellipse
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5084-6-9"
+             cx="956.96753"
+             cy="98.177658"
+             rx="16.499159"
+             ry="11.416828" />
+          <circle
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5086-4-7"
+             cx="956.82031"
+             cy="95.010422"
+             r="1.620453" />
+          <rect
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect5088-5-5"
+             width="13.700193"
+             height="3.3882201"
+             x="949.89648"
+             y="82.046768"
+             rx="0.29462782"
+             ry="0.29462782" />
+          <rect
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect5090-8-0"
+             width="4.0104165"
+             height="9.140625"
+             x="954.7915"
+             y="82.604294"
+             rx="0.29462799"
+             ry="0.29462799" />
+        </g>
+        <g
+           inkscape:label="Bathroom Sink"
+           id="g5403">
+          <ellipse
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5082-0-5-0"
+             cx="1028.9108"
+             cy="95.903168"
+             rx="18.41424"
+             ry="15.541617" />
+          <ellipse
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5084-6-9-7"
+             cx="1029.058"
+             cy="97.965546"
+             rx="16.499159"
+             ry="11.416828" />
+          <circle
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5086-4-7-2"
+             cx="1028.9108"
+             cy="94.798309"
+             r="1.620453" />
+          <rect
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect5088-5-5-0"
+             width="13.700193"
+             height="3.3882201"
+             x="1021.9869"
+             y="81.834656"
+             rx="0.29462782"
+             ry="0.29462782" />
+          <rect
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect5090-8-0-4"
+             width="4.0104165"
+             height="9.140625"
+             x="1026.882"
+             y="82.392181"
+             rx="0.29462799"
+             ry="0.29462799" />
+        </g>
+        <path
+           inkscape:label="Bathroom Counter"
+           inkscape:connector-curvature="0"
+           id="path5159"
+           d="M 1054.7676,75.618923 V 113.62591 H 930.87661 m 0.11297,-35.875909 h 123.75002"
+           style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:label="Shower"
+           inkscape:connector-curvature="0"
+           id="path5165"
+           d="m 1109.2708,244.10416 -68.6458,-68.64583 h 68.9583 l -68.5417,68.54165"
+           style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <g
+           inkscape:label="Master Bathtub"
+           id="g5173">
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 930.625,175.66667 h 103.5417"
+             id="path5163"
+             inkscape:connector-curvature="0" />
+          <rect
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect5169"
+             width="92.291664"
+             height="54.166668"
+             x="935.83307"
+             y="183.58333"
+             rx="4.044632"
+             ry="4.044632" />
+        </g>
+        <g
+           inkscape:label="Toilet"
+           id="g5413">
+          <rect
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect5175-1"
+             width="38.333332"
+             height="10.625"
+             x="1062.9302"
+             y="79.426056"
+             rx="2.06545"
+             ry="2.06545" />
+          <ellipse
+             style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path5177-3"
+             cx="1082.3572"
+             cy="106.45731"
+             rx="13.072917"
+             ry="16.40625" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 1072.0968,90.15523 v 6.14584"
+             id="path5196-9"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 1092.6176,90.15523 v 6.14584"
+             id="path5196-5-8"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         inkscape:label="Range"
+         id="g5008">
+        <rect
+           style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4949"
+           width="52.001812"
+           height="42.279095"
+           x="1551.0682"
+           y="383.21036" />
+        <path
+           style="fill:none;stroke:#464646;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 1550.9375,418.6875 h 52.1875"
+           id="path4983"
+           inkscape:connector-curvature="0" />
+        <circle
+           style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+           id="path4966"
+           cx="1563.5939"
+           cy="393.11459"
+           r="7.4479165" />
+        <circle
+           style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+           id="path4966-3"
+           cx="1590.8855"
+           cy="393.11508"
+           r="7.4479165" />
+        <circle
+           style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+           id="path4985"
+           cx="1564.0104"
+           cy="409.46875"
+           r="5.5729165" />
+        <circle
+           style="opacity:1;fill:none;stroke:#464646;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+           id="path4985-5"
+           cx="1590.7808"
+           cy="409.46909"
+           r="5.5729165" />
+      </g>
+      <g
+         inkscape:label="Walls"
+         id="main_structure_walls">
+        <path
+           id="basement_structure_walls_path_16"
+           d="m 1496.5955,29.4043 c 1.867,-1.94117 3.771,-3.84526 5.6999,-5.71225 4.7725,0 9.5575,0.0124 14.3424,-0.0124 0.037,3.84526 -0.012,7.67815 0.05,11.53577 -3.2394,0.0247 -6.4665,0.0247 -9.6812,0.0247 -0.5687,0.56875 -1.7186,1.69389 -2.2873,2.26264 -2.7078,-2.72011 -5.3784,-5.4526 -8.1233,-8.09853 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 16" />
+        <path
+           id="basement_structure_walls_path_15"
+           d="m 1641.5407,23.70442 c 4.7973,0 9.6069,-0.0124 14.4166,-0.0247 2.3121,1.38479 3.8824,3.74634 5.9224,5.50206 -2.6335,2.81903 -5.4278,5.48969 -8.1479,8.20981 -0.7295,-0.72949 -1.4343,-1.44661 -2.1267,-2.15137 -3.363,-0.0124 -6.7137,-0.0124 -10.0644,0 -0.012,-3.85762 -0.012,-7.70288 0,-11.53577 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 15" />
+        <path
+           id="basement_structure_walls_path_14"
+           d="m 1461.0608,64.48146 c 2.2874,-1.29824 3.7958,-3.70925 5.8236,-5.39078 2.7077,2.72012 5.4278,5.42787 8.1356,8.14799 -2.9303,2.93031 -5.873,5.84825 -8.7909,8.80329 -40.8884,0 -81.7767,0 -122.665,0 -0.012,-3.85762 -0.012,-7.70288 0,-11.53577 39.1573,-0.0247 78.327,0.0247 117.4967,-0.0247 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 14" />
+        <path
+           id="basement_structure_walls_path_13"
+           d="m 1683.4676,67.15212 c 2.7325,-2.70776 5.4526,-5.44024 8.1727,-8.17272 1.9412,1.95354 3.9071,3.91944 5.9225,5.82353 0.049,72.1573 0.012,144.32698 0.025,216.48428 -3.8576,-0.0124 -7.7029,-0.0124 -11.5358,0 -0.037,-70.56233 0.049,-141.12466 -0.05,-211.68699 -0.6305,-0.60584 -1.904,-1.84226 -2.5346,-2.4481 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 13" />
+        <path
+           id="basement_structure_walls_path_12"
+           d="m 645.39627,64.50619 c 30.91044,0 61.82087,0 92.73131,0 0,3.83289 0,7.67815 0,11.53577 -27.07754,0.0247 -54.14272,-0.0371 -81.22026,0.0371 0.0618,88.87367 0.0124,177.74734 0.0247,266.62101 61.68486,0 123.36973,0 185.05459,0 0.0124,7.01048 -0.0371,14.02097 0.0371,21.04382 6.71375,-0.0618 13.43986,-0.0247 20.15361,-0.0247 0,2.59647 0,5.20531 0,7.82652 -6.72612,0 -13.46459,0 -20.1907,0 -0.0247,7.70288 0.0371,15.39339 -0.0371,23.10864 -2.60884,-0.0371 -5.20532,-0.0371 -7.81416,-0.0495 0.0618,-14.68864 -0.0247,-29.36491 0.0495,-44.04118 -59.08839,-0.0618 -118.18914,-0.0618 -177.27753,0 0.0618,34.05093 0.0124,68.11422 0.0247,102.17752 43.831,0 87.64963,0 131.48062,0 0,2.59647 0,5.20531 0,7.82652 -1.23641,0 -3.70925,0 -4.94567,0 -0.0124,13.45222 0.0124,26.90444 -0.0247,40.35665 10.29935,0.0865 20.59871,-0.0371 30.89807,0.0618 6.63956,-6.59011 13.25439,-13.20494 19.8445,-19.83214 -0.0618,-6.86211 -0.0371,-13.71186 0,-20.54925 -1.80517,-0.0495 -3.61034,-0.0618 -5.40315,-0.0742 0,-2.60884 0.0124,-5.21768 0.0495,-7.81415 1.76808,0 3.54852,0.0124 5.32896,0.0247 0,-2.20083 -0.0124,-4.40165 -0.0247,-6.56538 2.60884,-0.0371 5.20532,-0.0618 7.81416,-0.0618 0.0865,11.46159 0,22.92318 0.0495,34.39713 2.25028,2.26264 4.58711,4.43873 6.70139,6.84975 -1.94118,1.68153 -3.70926,3.54852 -5.52679,5.37841 -1.58261,-1.57025 -3.1405,-3.15286 -4.71075,-4.72311 -6.94867,6.89921 -13.86024,13.84787 -20.78418,20.78417 -17.3222,-0.0494 -34.64441,0.0371 -51.96662,-0.0494 0.0124,-2.62121 0.0247,-5.23005 0.0866,-7.82653 3.27651,0.0495 6.55301,0.0247 9.82952,0.0371 0,-13.47695 0,-26.92917 0,-40.39375 -39.56536,0.0247 -79.14308,-0.0495 -118.7208,0.0371 0.0618,13.43985 0.0124,26.89207 0.0247,40.35666 4.40165,-0.0124 8.79093,-0.0124 13.19258,0 0,2.59647 0,5.20531 0,7.82652 -4.40165,0 -8.80329,-0.0371 -13.21731,0.0247 0.0742,75.14943 -0.0247,150.28651 0.0618,225.43601 20.19069,-0.025 40.38139,-0.049 60.57209,0 -0.0371,3.8205 -0.0371,7.6534 0,11.4986 -24.03596,0.074 -48.07191,-0.037 -72.10787,0.049 -0.0742,-227.10514 -0.0124,-454.19789 -0.0371,-681.29063 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 12" />
+        <path
+           id="basement_structure_walls_path_11"
+           d="m 842.39466,64.50619 c 72.81262,0 145.62524,0 218.43784,0 0,3.83289 0,7.67815 0,11.53577 -43.1509,0.0247 -86.28955,-0.0371 -129.44052,0.0247 0.0742,14.26825 -0.0124,28.53651 0.0495,42.80476 -2.60884,0.0247 -5.21768,0.0371 -7.81416,0.0618 -0.0742,-14.30535 -0.0124,-28.59833 -0.0371,-42.89131 -27.06518,0 -54.13036,0 -81.19553,0 0,-3.85762 0,-7.70288 0,-11.53577 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 11" />
+        <path
+           id="basement_structure_walls_path_10"
+           d="m 1103.2787,64.50619 c 27.2012,0 54.4024,0 81.6036,0 0,3.83289 0,7.67815 0,11.53577 -22.6759,0.0247 -45.3518,-0.0371 -68.0277,0.0371 0.062,88.87367 0.012,177.74734 0.025,266.62101 10.9917,0 21.9835,-0.0124 32.9752,0 0,2.60884 0,5.2424 0,7.87597 -72.8373,-0.0494 -145.6747,-0.14837 -218.49964,0.0495 0.0989,6.98576 0.13601,13.97151 -0.0124,20.95727 -2.58411,-0.0124 -5.16822,-0.0247 -7.75233,-0.0247 -3.30124,-0.0371 -6.60247,-0.0247 -9.89134,-0.0124 0,-2.62121 0,-5.23005 0,-7.82652 3.28887,-0.0124 6.56538,-0.0247 9.86661,0.0247 0.0618,-20.06705 0,-40.13411 0.0247,-60.20116 2.60884,-0.0124 5.21768,-0.0124 7.82652,0 0,13.0442 0,26.10077 0,39.15734 59.19967,0.0124 118.39938,-0.0371 177.59898,0.0247 0.074,-30.51477 0.012,-61.01718 0.037,-91.5196 -59.212,0 -118.42404,0 -177.63607,0 0,1.61971 0.0124,3.25178 0.0371,4.89621 -2.60884,0.0371 -5.23004,0.0495 -7.82652,0.0618 -0.0742,-28.84562 -0.0124,-57.7036 -0.0371,-86.56157 2.60884,-0.0124 5.21768,-0.0124 7.82652,0 0.0247,24.59234 -0.0371,49.18467 0.0247,73.78938 34.0633,-0.0989 68.1266,0.0989 102.18987,-0.0989 2.5965,-0.16073 5.2053,-0.1731 7.8142,-0.0124 22.5275,0.21019 45.0674,0.0371 67.6073,0.0865 0,-55.77478 0,-111.54956 0,-167.32434 -1.9288,-0.0124 -3.8576,-0.0124 -5.7741,0 0,-3.85762 0,-7.70288 0,-11.53577 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 10" />
+        <path
+           id="basement_structure_walls_path_9"
+           d="m 1257.8062,76.01723 c 0.049,-3.85762 0,-7.69052 0.049,-11.53577 4.2409,0.0247 8.4818,0.0247 12.7227,0 0.062,3.84525 0,7.67815 0.062,11.52341 -4.278,0.0495 -8.556,0.0495 -12.834,0.0124 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 9" />
+        <path
+           id="basement_structure_walls_path_8"
+           d="m 1686.0517,343.93647 c 3.8329,-0.0124 7.6782,-0.0124 11.5358,0 -0.025,89.02204 0.037,178.05644 -0.037,267.09083 -2.6089,-0.037 -5.2177,-0.049 -7.8142,-0.049 0.025,-58.11165 0.05,-116.22326 -0.012,-174.33487 -66.0618,0.0247 -132.1112,0.0371 -198.173,0 -0.074,48.09663 -0.012,96.1809 -0.037,144.26516 -41.3458,0 -82.704,0 -124.0498,0 0,-3.85762 0,-7.70288 0,-11.53577 2.0525,-0.0124 4.1173,-0.0124 6.1821,0 -0.012,-2.21319 -0.012,-4.41401 0,-6.5901 2.6089,-0.0124 5.2177,-0.0247 7.8265,0 0,2.16373 -0.012,4.35219 -0.025,6.55301 32.8393,0.0742 65.6909,0.0124 98.5301,0.0371 0,-45.47542 0,-90.95085 0,-136.41391 -32.8268,-0.0124 -65.6537,0.0124 -98.4806,-0.0247 -0.062,22.94791 0,45.89581 -0.025,68.84371 -2.6212,-0.0124 -5.2301,-0.0124 -7.8265,0 0,-41.48179 0,-82.97596 0,-124.45775 7.1465,-0.0124 14.2806,-0.0124 21.4271,0 0,2.59647 0,5.20531 0,7.82652 -4.5377,0 -9.0877,-0.0371 -13.6253,0.0371 0.087,13.31621 -0.025,26.63243 0.062,39.961 24.8396,-0.0371 49.6916,-0.0371 74.5312,0 0.087,-13.32857 -0.025,-26.64479 0.062,-39.961 -4.55,-0.0742 -9.0877,-0.0371 -13.6253,-0.0371 -0.012,-2.62121 -0.012,-5.23005 0,-7.82652 7.1341,-0.0124 14.2806,-0.0124 21.4271,0 0,15.92505 0,31.86247 0,47.79989 74.0367,0.0124 148.0733,-0.0124 222.1224,0.0247 0.062,-27.07753 0,-54.1427 0.025,-81.20788 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 8" />
+        <path
+           id="basement_structure_walls_path_7"
+           d="m 1239.705,425.54001 c 18.6823,-0.0124 37.3646,0 56.0468,0 0,4.7973 0,9.60696 0,14.41662 -2.6212,-0.0124 -5.23,-0.0124 -7.8265,0 -0.025,-2.20082 -0.012,-4.38928 0.025,-6.55301 -13.4769,-0.0865 -26.9539,-0.0247 -40.4185,-0.0371 0,21.42711 0,42.86658 0,64.29369 13.4646,-0.0247 26.9416,0.0371 40.4185,-0.0371 -0.025,-2.32446 -0.05,-4.64893 -0.05,-6.9363 2.5965,-0.0371 5.2053,-0.0618 7.8142,-0.0618 0.074,26.24914 0.012,52.49827 0.037,78.74741 3.0168,-0.0124 6.0337,-0.0124 9.0629,0 0,3.83289 0,7.67815 0,11.53577 -18.0022,0.0247 -36.0045,-0.0371 -54.0067,0.0247 0.037,155.36821 0.012,310.73641 0.025,466.10461 18.2619,-0.012 36.5238,0.037 54.7856,-0.025 0.025,2.6089 0.025,5.2425 -0.012,7.8884 -20.8707,-0.062 -41.7414,-0.012 -62.6121,-0.025 0.012,-157.9771 -0.012,-315.9541 0.025,-473.93114 -6.6025,-0.0618 -13.1926,-0.0495 -19.7703,-0.0124 -0.074,-3.85762 -0.012,-7.70288 -0.062,-11.53577 5.5144,-0.0742 11.0288,0.0124 16.5432,-0.0618 -0.037,-3.01686 -0.037,-6.03372 -0.025,-9.02585 2.5965,-0.0247 5.2053,-0.0124 7.8265,0 -0.012,3.0045 0,6.03372 0,9.06294 13.4646,-0.0247 26.9416,0.0371 40.4185,-0.0371 -0.062,-21.27874 -0.012,-42.55748 -0.025,-63.84859 -13.4646,-0.0124 -26.9168,0.0371 -40.3566,-0.0247 -0.05,2.47283 -0.05,4.94566 -0.037,7.44323 -2.6212,-0.0124 -5.2301,-0.0124 -7.8266,0 0,-29.11763 0,-58.24762 0,-87.36524 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 7" />
+        <path
+           id="basement_structure_walls_path_6"
+           d="m 931.08288,487.39796 c 2.37392,-2.32446 4.71075,-4.69838 7.05994,-7.04758 66.45748,0 132.90248,0 199.34758,0 0,29.67402 0,59.34803 0,89.02204 7.7029,0.0124 15.4058,-0.0495 23.1086,0.0371 -0.062,3.82053 0,7.66579 -0.062,11.52341 -6.4293,-0.0618 -12.8711,0.0124 -19.3004,-0.0495 -0.074,41.22217 -0.012,82.44437 -0.037,123.66647 -30.9105,0 -61.8209,0 -92.7313,0 0,-3.8576 0,-7.7029 0,-11.5358 27.0775,-0.025 54.1427,0.05 81.2202,-0.037 -0.062,-68.2625 -0.012,-136.52517 -0.025,-204.80013 -62.7605,0 -125.5211,0.0124 -188.28164,-0.0124 -1.57025,1.57025 -3.12813,3.15286 -4.67365,4.76021 -1.95354,-1.76808 -3.7958,-3.64744 -5.6257,-5.52679 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 6" />
+        <path
+           id="path6395"
+           d="m 879.61082,529.04049 c 1.90408,-1.74335 3.70925,-3.57324 5.52679,-5.40314 1.6197,1.60734 3.23941,3.22705 4.84675,4.87148 1.54552,-1.52079 3.06632,-3.06631 4.53765,-4.63656 1.90409,1.74335 3.67216,3.65979 5.65043,5.35368 -1.47133,1.66917 -3.02922,3.25178 -4.63656,4.80967 7.31959,7.33195 14.67627,14.65154 21.9835,22.00822 0.0178,2.5537 0.29674,17.41234 0.29674,19.91868 -2.60884,-0.0124 -5.21768,-0.0124 -7.82652,0 V 559.5429 c -6.67666,-6.65192 -13.32858,-13.31621 -19.99287,-19.9805 -6.8003,6.8003 -13.57587,13.62532 -20.41325,20.38852 0.0124,44.33788 0.0495,88.68818 -0.0124,133.02608 13.47695,0.074 26.94154,0.012 40.41849,0.037 v -15.245 c 2.60884,-0.012 5.21768,-0.025 7.82652,0 -0.0124,5.057 0.0247,10.1386 -0.0247,15.2079 15.66541,0.074 31.34318,0.012 47.00859,0.037 v 11.5358 h -91.49489 c 0.0124,13.7366 -0.0124,27.4608 0.0247,41.1851 -24.03595,0.087 -48.07191,-0.025 -72.10786,0.062 -0.0618,-3.8824 -0.0618,-7.74 0,-11.5976 20.17833,0.062 40.35666,0.012 60.54736,0.025 V 556.72387 c 7.55451,-7.61633 15.24502,-15.09665 22.70062,-22.81189 -1.71862,-1.53316 -3.33833,-3.16523 -4.85912,-4.87149 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 5" />
+        <path
+           id="path6393"
+           d="m 1689.761,673.6395 c 2.5964,-0.012 5.2053,-0.012 7.8265,0 0,37.3645 0,74.7414 0,112.1059 -2.6212,-0.012 -5.2301,-0.012 -7.8265,0 0,-37.3645 0,-74.729 0,-112.1059 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 4" />
+        <path
+           id="path6391"
+           d="m 1689.761,869.4138 c 2.5964,-0.025 5.2053,-0.025 7.8265,0 -0.025,61.8208 0.037,123.6541 -0.037,185.4873 -20.8707,-0.062 -41.7415,-0.012 -62.6122,-0.025 -0.012,-2.6336 -0.012,-5.2424 0,-7.8389 18.2619,0.012 36.5238,-0.025 54.7857,0.025 0.074,-59.2244 0.012,-118.4364 0.037,-177.6484 z"
+           inkscape:connector-curvature="0"
+           style="fill:#9a9a9b"
+           inkscape:label="Path 3" />
+        <path
+           id="path6389"
+           d="m 1033.6313,174.54732 c 2.6089,-0.0124 5.2177,-0.0124 7.8266,0 0,22.91081 0.025,45.82162 -0.012,68.73243 -2.6089,-0.16074 -5.2177,-0.14837 -7.8142,0.0124 0,-22.92317 0,-45.83398 0,-68.74479 z"
+           inkscape:connector-curvature="0"
+           style="fill:#636365"
+           inkscape:label="Path 2" />
+        <path
+           id="path6387"
+           d="m 923.59019,371.55803 c 2.58411,0 5.16822,0.0124 7.75233,0.0247 -0.21019,13.16784 -0.0742,26.34805 -0.0618,39.5159 12.67328,0.59348 25.37129,0.11127 38.0693,0.27201 60.16408,-0.14837 120.32818,0.28437 180.49218,-0.22256 0.012,2.73248 0.012,5.47733 -0.025,8.23454 -75.3967,-0.0495 -150.79344,-0.0495 -226.19017,0 -0.0865,-15.93742 -0.0124,-31.8872 -0.0371,-47.82462 z"
+           inkscape:connector-curvature="0"
+           style="fill:#636365"
+           inkscape:label="Path 1" />
+      </g>
+      <g
+         inkscape:label="Stairs"
+         id="main_structure_stairs">
+        <path
+           id="main_structure_stairs_back"
+           d="m 931.35489,350.62549 c 72.82501,-0.19783 145.66231,-0.0989 218.49971,-0.0495 0,20.1907 0.012,40.38139 -0.012,60.57208 -60.1641,0.50693 -120.3281,0.0742 -180.4922,0.22256 -12.69801,-0.16074 -25.39602,0.32147 -38.06929,-0.27201 -0.0124,-13.16785 -0.14837,-26.34806 0.0618,-39.5159 0.14837,-6.98576 0.11127,-13.97151 0.0124,-20.95727 z"
+           inkscape:connector-curvature="0"
+           style="fill:#585959"
+           inkscape:label="Background" />
+        <path
+           id="main_structure_stairs_line_13"
+           d="m 940.90003,350.5997 h 1.23642 c 0,20.19069 0,40.38138 0,60.58444 h -1.23642 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 13" />
+        <path
+           id="main_structure_stairs_line_12"
+           d="m 958.20988,350.5997 h 1.23641 c 0,20.19069 0,40.38138 0,60.58444 h -1.23641 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 12" />
+        <path
+           id="main_structure_stairs_line_11"
+           d="m 975.51972,350.5997 h 1.23642 c 0,20.19069 0,40.38138 0,60.58444 h -1.23642 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 11" />
+        <path
+           id="main_structure_stairs_line_10"
+           d="m 992.82956,350.5997 h 1.23642 c 0,20.19069 0,40.38138 0,60.58444 h -1.23642 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 10" />
+        <path
+           id="main_structure_stairs_line_9"
+           d="m 1010.1394,350.5997 h 1.2364 c 0,20.19069 0,40.38138 0,60.58444 h -1.2364 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 9" />
+        <path
+           id="main_structure_stairs_line_8"
+           d="m 1027.4493,350.5997 h 1.2364 c 0,20.19069 0,40.38138 0,60.58444 h -1.2364 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 8" />
+        <path
+           id="main_structure_stairs_line_7"
+           d="m 1044.7591,350.5997 h 1.2364 c 0,20.19069 0,40.38138 0,60.58444 h -1.2364 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 7" />
+        <path
+           id="main_structure_stairs_line_6"
+           d="m 1062.0689,350.5997 h 1.2365 c 0,20.19069 0,40.38138 0,60.58444 h -1.2365 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 6" />
+        <path
+           id="main_structure_stairs_line_5"
+           d="m 1079.3788,350.5997 h 1.2364 c 0,20.19069 0,40.38138 0,60.58444 h -1.2364 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 5" />
+        <path
+           id="main_structure_stairs_line_4"
+           d="m 1096.6886,350.5997 h 1.2364 c 0,20.19069 0,40.38138 0,60.58444 h -1.2364 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 4" />
+        <path
+           id="main_structure_stairs_line_3"
+           d="m 1113.9985,350.5997 h 1.2364 c 0,20.19069 0,40.38138 0,60.58444 h -1.2364 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 3" />
+        <path
+           id="main_structure_stairs_line_2"
+           d="m 1131.3083,350.5997 h 1.2364 c 0,20.19069 0,40.38138 0,60.58444 h -1.2364 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 2" />
+        <path
+           id="main_structure_stairs_line_1"
+           d="m 1148.6182,350.5997 h 1.2364 c 0,20.19069 0,40.38138 0,60.58444 h -1.2364 c 0,-20.20306 0,-40.39375 0,-60.58444 z"
+           inkscape:connector-curvature="0"
+           style="fill:#000000"
+           inkscape:label="Line 1" />
+        <path
+           style="fill:#00adee"
+           inkscape:connector-curvature="0"
+           d="m 1137.365,380.90531 13.8416,-7.63681 -0.9546,4.05711 h 7.1595 v 7.15942 h -7.1595 l 0.716,4.05687 z"
+           class="st9"
+           id="main_structure_stairs_arrow"
+           inkscape:label="Arrow" />
+      </g>
+      <g
+         inkscape:label="Windows"
+         id="main_structure_windows">
+        <rect
+           style="fill:#505050"
+           id="window_garage"
+           width="10.7"
+           height="83.600006"
+           x="1689.761"
+           y="785.74542"
+           inkscape:label="Garage" />
+        <rect
+           style="fill:#505050"
+           id="window_bedroom-2"
+           width="83.599998"
+           height="14.4"
+           x="964.79999"
+           y="693.0141"
+           inkscape:label="Bedroom 2" />
+        <rect
+           style="fill:#505050"
+           id="window_bedroom-1"
+           width="83.599998"
+           height="14.4"
+           x="717.5412"
+           y="734.24872"
+           inkscape:label="Bedroom 1" />
+        <rect
+           style="fill:#505050"
+           id="window_kitchen"
+           width="14.4"
+           height="62.600006"
+           x="1686.0518"
+           y="281.28723"
+           inkscape:label="Kitchen" />
+        <rect
+           style="fill:#505050"
+           id="window_dining_room-2"
+           width="41.999981"
+           height="14.399993"
+           x="1195.8041"
+           y="-1157.3251"
+           transform="rotate(45)"
+           inkscape:label="Dining Room 2" />
+        <rect
+           style="fill:#505050"
+           id="window_dining_room-1"
+           width="41.999981"
+           height="14.399993"
+           x="995.47955"
+           y="1076.1146"
+           transform="rotate(-45)"
+           inkscape:label="Dining Room 1" />
+        <rect
+           style="fill:#505050"
+           id="window_living_room-2"
+           width="73.000008"
+           height="14.4"
+           x="1270.6401"
+           y="61.604828"
+           inkscape:label="Living Room 2" />
+        <rect
+           style="fill:#505050"
+           id="window_living_room-1"
+           width="73.000008"
+           height="14.4"
+           x="1184.8822"
+           y="61.641968"
+           inkscape:label="Living Room 1" />
+        <rect
+           style="fill:#505050"
+           id="windows_m_bathroom"
+           width="42.500004"
+           height="14.4"
+           x="1060.8325"
+           y="61.641968"
+           inkscape:label="M Bathroom" />
+        <rect
+           style="fill:#505050"
+           id="window_m_bedroom"
+           width="104.3"
+           height="14.4"
+           x="738.12756"
+           y="61.641968"
+           inkscape:label="M Bedroom" />
+        <rect
+           style="fill:#505050"
+           id="window_sliding_glass"
+           width="62.399994"
+           height="6.200007"
+           x="1579.1406"
+           y="21.610474"
+           inkscape:label="Sliding Glass" />
+      </g>
+      <g
+         inkscape:label="Closet Bedroom 2"
+         id="main_structure_closet_2">
+        <path
+           style="fill:#505050;stroke-width:1.23641729"
+           inkscape:connector-curvature="0"
+           d="m 917.91503,575.57924 c 11.95616,6.39227 23.6403,13.37803 35.31208,20.2896 -11.77069,6.61486 -23.41774,13.46456 -35.12662,20.21546 -0.42038,-0.7048 -1.28587,-2.1019 -1.71862,-2.8067 10.1139,-5.8606 20.24016,-11.6718 30.34169,-17.5324 -10.1139,-5.82353 -20.1907,-11.69651 -30.32932,-17.48294 0.38329,-0.66766 1.1375,-2.01536 1.52079,-2.68302 z"
+           id="main_structure_closet_2-2"
+           inkscape:label="Path 2" />
+        <path
+           style="fill:#505050;stroke-width:1.23641729"
+           inkscape:connector-curvature="0"
+           d="m 916.38187,640.4417 c 0.43275,-0.6924 1.29824,-2.0896 1.73099,-2.7943 11.69651,6.7755 23.36829,13.5882 35.12662,20.2525 -10.9423,6.5777 -22.11951,12.7969 -33.13599,19.251 -1.90408,1.6568 -3.07868,0.3462 -3.70925,-1.6815 10.13862,-5.737 20.14124,-11.7089 30.30459,-17.3964 -10.00262,-6.0461 -20.24015,-11.7089 -30.31696,-17.6313 z"
+           id="main_structure_closet_2-1"
+           inkscape:label="Path 1" />
+      </g>
+      <g
+         inkscape:label="Closet Bedroom 1"
+         id="main_structure_closet_1">
+        <path
+           style="fill:#505050;stroke-width:1.23641729"
+           inkscape:connector-curvature="0"
+           d="m 725.6274,509.03526 c 0.70476,-0.42038 2.11427,-1.23642 2.81903,-1.6568 5.83589,10.10153 11.68414,20.1907 17.48294,30.30459 5.81116,-10.03971 11.7336,-20.02996 17.3593,-30.18095 1.01386,0.46984 2.02773,0.95205 3.02922,1.47134 -6.77556,11.77069 -13.57586,23.51666 -20.36379,35.28735 -6.7632,-11.75833 -13.5635,-23.47957 -20.3267,-35.22553 z"
+           id="main_structure_closet_1-2"
+           inkscape:label="Path 2" />
+        <path
+           style="fill:#505050;stroke-width:1.23641729"
+           inkscape:connector-curvature="0"
+           d="m 669.5806,509.0229 c 0.70476,-0.40802 2.11427,-1.22406 2.81903,-1.63207 5.83589,10.10153 11.67178,20.20305 17.50767,30.31695 5.83589,-10.10153 11.65942,-20.21542 17.50767,-30.31695 0.70476,0.40801 2.11427,1.21169 2.81903,1.6197 -6.73847,11.77069 -13.5635,23.49193 -20.3267,35.23789 -6.77557,-11.7336 -13.5635,-23.47956 -20.3267,-35.22552 z"
+           id="main_structure_closet_1-1"
+           inkscape:label="Path 1" />
+      </g>
+      <g
+         id="main_structure_doors"
+         inkscape:label="Doors">
+        <path
+           id="3068_door_garage_outside"
+           d="m 1689.7383,672.7107 c -31.9306,0.304 -58.39,-23.7201 -61.7351,-55.6508 h 61.7328 v -6.082 h -62.9491 c 0,34.6676 27.9772,62.6451 62.6448,62.6451 v 0 h 0.3043 z"
+           inkscape:connector-curvature="0"
+           style="fill:#505050"
+           inkscape:label="#3068 Door Garage Outside" />
+        <path
+           inkscape:label="#3068 Door Garage Entry"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 1305.7272,569.37477 c -0.304,-31.9306 23.72,-58.39005 55.6508,-61.73518 v 61.73283 h 6.082 v -62.94909 c -34.6676,0 -62.6452,27.97715 -62.6452,62.64481 v 0 0.30428 z"
+           id="3068_door_garage_entry" />
+        <path
+           inkscape:label="#3068 Door Front"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 1161.4537,569.3995 c -0.3042,-31.9306 23.7199,-58.39005 55.6507,-61.73518 v 61.73283 h 6.0821 v -62.94909 c -34.6677,0 -62.6452,27.97715 -62.6452,62.64481 v 0 0.30428 z"
+           id="3068_door_front" />
+        <path
+           inkscape:label="#2468 Door Entry Closet"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 1239.7068,513.86669 c -24.0221,-0.22887 -43.9281,17.84496 -46.4447,41.86718 h 46.4429 v 4.57561 h -47.3579 c 0,-26.08123 21.0477,-47.12925 47.129,-47.12925 v 0 h 0.2289 z"
+           id="2668_door_entry_closet" />
+        <path
+           id="2668_door_pantry"
+           d="m 1441.516,377.32149 c 0.2289,-24.0221 -17.8449,-43.92808 -41.8672,-46.4447 v 46.44295 h -4.5756 v -47.35797 c 26.0813,0 47.1293,21.04779 47.1293,47.12904 v 0 0.22893 z"
+           inkscape:connector-curvature="0"
+           style="fill:#505050"
+           inkscape:label="#2468 Door Pantry" />
+        <path
+           inkscape:label="#2368 Door Bathroom Closet"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 789.32223,452.71795 c -0.1947,-20.43561 15.18072,-37.36964 35.61645,-39.51054 v 39.50905 h 3.89248 V 412.429 c -22.18733,0 -40.0929,17.90538 -40.0929,40.09271 v 0 0.19475 z"
+           id="2368_door_bathroom_closet" />
+        <path
+           id="2668_door_bathroom"
+           d="m 834.13732,395.30983 c -26.30993,-0.25062 -48.11172,19.54453 -50.86802,45.85455 h 50.86609 v 5.01143 h -51.86825 c 0,-28.56516 23.05234,-51.61775 51.61753,-51.61775 v 0 h 0.25072 z"
+           inkscape:connector-curvature="0"
+           style="fill:#505050"
+           inkscape:label="#2668 Door Bathroom" />
+        <path
+           inkscape:label="#2668 Door Bedroom M"
+           style="fill:#505050"
+           inkscape:connector-curvature="0"
+           d="m 862.83286,363.72108 c -0.25062,-26.30992 19.54453,-48.11172 45.85455,-50.86801 v 50.86608 h 5.01144 V 311.8509 c -28.56516,0 -51.61776,23.05235 -51.61776,51.61753 v 0 0.25072 z"
+           id="2668_door_bedroom_m" />
+        <path
+           id="2468_door_master_closet"
+           d="m 931.45205,302.54424 c 24.0221,0.22884 43.92809,-17.845 46.44471,-41.86719 H 931.4538 v -4.57566 h 47.35798 c 0,26.08124 -21.04779,47.12925 -47.12905,47.12925 v 0 h -0.22893 z"
+           inkscape:connector-curvature="0"
+           style="fill:#505050"
+           inkscape:label="#2468 Door Master Closet" />
+        <path
+           id="2668_door_bathroom_m"
+           d="m 931.41478,118.73567 c 26.30992,-0.25063 48.11172,19.54453 50.86802,45.85454 h -50.86609 v 5.01144 h 51.86825 c 0,-28.56516 -23.05234,-51.61775 -51.61753,-51.61775 v 0 h -0.25072 z"
+           inkscape:connector-curvature="0"
+           style="fill:#505050"
+           inkscape:label="#2668 Door Bathroom M" />
+        <path
+           id="2668_door_bedroom_2"
+           d="m 936.13876,493.25697 c 18.78114,18.4267 20.20006,47.8402 3.54506,68.39316 l -35.96776,-35.96775 -3.54362,3.54357 36.6764,36.67647 c 20.19862,-20.19873 20.19879,-52.79984 1.6e-4,-72.99845 v 0 l -0.17729,-0.1773 z"
+           inkscape:connector-curvature="0"
+           style="fill:#505050"
+           inkscape:label="#2668 Door Bedroom 2" />
+        <path
+           inkscape:connector-curvature="0"
+           inkscape:label="#2668 Door Bedroom 1"
+           style="fill:#505050"
+           d="m 843.6445,493.07151 c -18.78114,18.42669 -20.20005,47.84019 -3.54505,68.39316 l 35.96775,-35.96775 3.54362,3.54357 -36.67639,36.67646 c -20.19862,-20.19873 -20.1988,-52.79983 -1.6e-4,-72.99844 v 0 l 0.17729,-0.1773 z"
+           id="2668_door_bedroom_1" />
+      </g>
+      <g
+         id="main_structure_labels"
+         inkscape:label="Labels">
+        <text
+           transform="rotate(-90)"
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641729"
+           x="-626.99835"
+           y="1127.1884"
+           id="text1628"
+           inkscape:label="Bedroom 2"><tspan
+             sodipodi:role="line"
+             id="tspan1626"
+             x="-626.99835"
+             y="1127.1884"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290287">BEDROOM 2</tspan></text>
+        <text
+           transform="rotate(-90)"
+           inkscape:label="Bedroom 1"
+           id="text1624"
+           y="675.5813"
+           x="-668.18939"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641729"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290287"
+             y="675.5813"
+             x="-668.18939"
+             id="tspan1622"
+             sodipodi:role="line">BEDROOM 1</tspan></text>
+        <text
+           transform="rotate(-90)"
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641729"
+           x="-1000.8362"
+           y="1269.7913"
+           id="text1620"
+           inkscape:label="Garage"><tspan
+             sodipodi:role="line"
+             id="tspan1618"
+             x="-1000.8362"
+             y="1269.7913"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290287">GARAGE</tspan></text>
+        <text
+           transform="rotate(-90)"
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641729"
+           x="-516.49158"
+           y="1477.5353"
+           id="text1593"
+           inkscape:label="Laundry"><tspan
+             sodipodi:role="line"
+             id="tspan1591"
+             x="-516.49158"
+             y="1477.5353"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290287">LAUNDRY</tspan></text>
+        <text
+           transform="rotate(-90)"
+           inkscape:label="Kitchen"
+           id="text1601"
+           y="1682.8357"
+           x="-375.90564"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641729"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290287"
+             y="1682.8357"
+             x="-375.90564"
+             id="tspan1599"
+             sodipodi:role="line">KITCHEN</tspan></text>
+        <text
+           transform="rotate(-90)"
+           inkscape:label="Dining"
+           id="text1597"
+           y="1682.8679"
+           x="-168.48828"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641729"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290287"
+             y="1682.8679"
+             x="-168.48828"
+             id="tspan1595"
+             sodipodi:role="line">DINING</tspan></text>
+        <text
+           transform="rotate(-90)"
+           inkscape:label="Living Room"
+           id="text1567"
+           y="1135.6399"
+           x="-305.63861"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641729"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290287"
+             y="1135.6399"
+             x="-305.63861"
+             id="tspan1565"
+             sodipodi:role="line">LIVING</tspan></text>
+        <text
+           transform="rotate(-90)"
+           inkscape:label="Master Bath"
+           id="text1583"
+           y="950.31903"
+           x="-212.76996"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641729"
+           xml:space="preserve"><tspan
+             id="tspan1587"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290287"
+             y="950.31903"
+             x="-212.76996"
+             sodipodi:role="line">BATH</tspan></text>
+        <text
+           transform="rotate(-90)"
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641729"
+           x="-422.45679"
+           y="675.76581"
+           id="text2362"
+           inkscape:label="Bathroom"><tspan
+             sodipodi:role="line"
+             id="tspan1630"
+             x="-422.45679"
+             y="675.76581"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290287">BATH</tspan></text>
+        <text
+           transform="rotate(-90)"
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#757575;stroke-width:1.23641729"
+           x="-269.79541"
+           y="675.58276"
+           id="text1575"
+           inkscape:label="Master Bedroom"><tspan
+             id="tspan1577"
+             sodipodi:role="line"
+             x="-269.79541"
+             y="675.58276"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:23.38751984px;line-height:0.80000001;font-family:Roboto;-inkscape-font-specification:'Roboto Medium';text-align:center;text-anchor:middle;fill:#757575;stroke-width:1.25290287">M. BEDROOM</tspan></text>
+      </g>
+    </g>
+    <g
+       id="cars"
+       inkscape:label="Cars">
+      <g
+         inkscape:label="Subaru"
+         id="cars_subaru">
+        <path
+           id="path14066"
+           d="m 1495.4783,925.10991 c 1.9806,0 3.6783,1.41478 3.6783,3.39546 v 34.52048 c 0,1.98068 -1.6977,3.67841 -3.6783,3.67841 -1.9808,0 -3.6785,-1.69773 -3.6785,-3.67841 v -34.52048 c -0.2829,-1.98068 1.4148,-3.39546 3.6785,-3.39546 z"
+           inkscape:connector-curvature="0"
+           style="stroke-width:2.82954788" />
+        <path
+           id="path14068"
+           d="m 1492.0828,767.78705 c 1.9807,0 3.6784,1.41477 3.6784,3.39545 v 34.52049 c 0,1.98068 -1.6977,3.67841 -3.6784,3.67841 -1.9808,0 -3.6784,-1.69773 -3.6784,-3.67841 V 771.1825 c 0,-1.98068 1.6976,-3.39545 3.6784,-3.39545 z"
+           inkscape:connector-curvature="0"
+           style="stroke-width:2.82954788" />
+        <path
+           id="path14070"
+           d="m 1612.6216,925.10991 c 1.9806,0 3.6783,1.41478 3.6783,3.39546 v 34.52048 c 0,1.98068 -1.6977,3.67841 -3.6783,3.67841 -1.9808,0 -3.6785,-1.69773 -3.6785,-3.67841 v -34.52048 c 0,-1.98068 1.6977,-3.39546 3.6785,-3.39546 z"
+           inkscape:connector-curvature="0"
+           style="stroke-width:2.82954788" />
+        <path
+           id="path14072"
+           d="m 1615.4511,767.78705 c 1.9806,0 3.6784,1.41477 3.6784,3.39545 v 34.52049 c 0,1.98068 -1.6978,3.67841 -3.6784,3.67841 -1.9807,0 -3.6785,-1.69773 -3.6785,-3.67841 V 771.1825 c 0,-1.98068 1.6978,-3.67841 3.6785,-3.39545 z"
+           inkscape:connector-curvature="0"
+           style="stroke-width:2.82954788" />
+        <path
+           id="path14062"
+           class="st0"
+           d="m 1627.9011,819.28482 c 0.283,-1.69773 0.283,-3.67842 -0.566,-5.37615 -1.4147,-1.98068 -9.0544,-5.09319 -12.7329,-4.24431 -0.283,2.26363 -0.283,4.52727 0,6.79091 3.9613,0.84887 13.2989,2.82955 13.2989,2.82955 z"
+           inkscape:connector-curvature="0"
+           style="fill:#231f26;stroke-width:2.82954788" />
+        <path
+           id="path14064"
+           class="st0"
+           d="m 1478.7839,819.28482 c -0.2829,-1.69773 -0.2829,-3.67842 0.5659,-5.37615 1.4148,-1.98068 9.0546,-5.09319 12.733,-4.24431 0.2829,2.26363 0.2829,4.52727 0,6.79091 -3.6784,0.84887 -13.2989,2.82955 -13.2989,2.82955 z"
+           inkscape:connector-curvature="0"
+           style="fill:#231f26;stroke-width:2.82954788" />
+        <path
+           id="path14074"
+           class="st0"
+           d="m 1490.102,747.98021 c 0,-6.22501 24.9001,-23.7682 34.2377,-23.7682 h 56.8738 c 14.9967,0 35.9353,19.24092 35.0864,24.90001 0,4.52729 -5.3761,216.17747 -5.6591,223.25134 -3.6783,15.27956 -29.9931,23.20229 -57.4398,23.20229 -30.2761,0 -56.025,-9.05455 -57.4398,-23.48525 0.2829,-9.3375 -5.3762,-217.87519 -5.6592,-224.10019 z"
+           inkscape:connector-curvature="0"
+           style="fill:#231f26;stroke-width:2.82954788" />
+        <path
+           id="path14082"
+           class="st2"
+           d="m 1495.4783,744.86771 c 1.6977,-4.52728 12.7329,-14.4307 24.9,-18.10911 -3.6785,2.82955 -1.6977,2.26363 -5.3762,4.52728 -7.3568,3.1125 -16.4113,13.01592 -16.4113,13.01592 -1.1319,0 -2.2637,0.28296 -3.1125,0.56591 z"
+           inkscape:connector-curvature="0"
+           style="fill:#ffffa6;stroke-width:2.82954788" />
+        <path
+           id="path14084"
+           class="st2"
+           d="m 1611.7726,744.86771 c -1.6977,-4.52728 -12.7329,-14.4307 -24.9,-18.10911 3.6785,2.82955 1.6977,2.26363 5.3762,4.52728 7.3568,3.1125 16.4113,13.01592 16.4113,13.01592 1.1319,0 1.9807,0.28296 3.1125,0.56591 z"
+           inkscape:connector-curvature="0"
+           style="fill:#ffffa6;stroke-width:2.82954788" />
+        <path
+           id="path14086"
+           class="st17"
+           d="m 1512.1726,961.61108 c 14.4306,3.96136 29.1443,5.94204 44.141,6.225 17.2602,0 28.2954,-2.54659 38.1988,-7.07387 6.225,9.33751 7.0739,16.97729 2.5466,22.35344 -13.016,9.3375 -30.842,10.46932 -39.8966,10.46932 -9.0546,0.28295 -35.9353,-0.56591 -47.5364,-12.16706 -3.1125,-5.94205 -3.1125,-11.03523 2.5466,-19.80683 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:2.82954788" />
+        <path
+           id="path14088"
+           class="st17"
+           d="m 1529.4328,839.37461 h 48.1023 c 2.2636,0 3.9614,1.41477 3.9614,3.67841 v 22.91933 c 0,2.26365 -1.9806,3.67842 -3.9614,3.67842 h -48.1023 c -2.2636,0 -3.9613,-1.41477 -3.9613,-3.67842 v -22.91933 c 0,-2.26364 1.6977,-3.67841 3.9613,-3.67841 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:2.82954788" />
+        <path
+           id="path14090"
+           class="st17"
+           d="m 1500.8544,798.91207 c 11.6011,-4.52727 35.3694,-8.7716 53.7614,-8.48864 18.3921,0.28295 29.7102,2.54659 52.0637,7.92273 -5.0932,13.86479 -12.1671,24.33411 -13.8648,34.80344 -1.9807,2.82955 -19.8068,-1.98068 -36.2183,-1.98068 -13.8647,0 -27.4466,1.13182 -41.0284,3.1125 -3.9613,-14.14774 -13.0159,-25.46594 -14.7136,-35.36935 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:2.82954788" />
+        <path
+           id="path14092"
+           class="st17"
+           d="m 1611.7726,815.04049 c 0,10.18638 -2.8295,60.83529 -2.8295,60.83529 l -10.4694,3.39545 c 0,0 -0.8488,-34.23753 0.283,-45.27276 1.1318,-7.92274 5.9421,-14.71365 13.0159,-18.95798 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:2.82954788" />
+        <path
+           id="path14094"
+           class="st17"
+           d="m 1495.4783,815.04049 c 0,10.18638 2.8295,60.83529 2.8295,60.83529 l 10.4694,3.39545 c 0,0 0.8488,-34.23753 -0.283,-45.27276 -1.4148,-7.92274 -6.2251,-14.71365 -13.0159,-18.95798 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:2.82954788" />
+        <path
+           id="path14096"
+           class="st17"
+           d="m 1596.7761,883.51556 c 0,0 11.0352,-4.52728 11.884,-3.96138 0.849,0.56591 0.849,54.04438 -0.8488,58.57165 -3.6785,1.98069 -10.7523,-1.98068 -10.7523,-1.98068 0,-17.5432 0,-35.0864 -0.2829,-52.62959 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:2.82954788" />
+        <path
+           id="path14098"
+           class="st17"
+           d="m 1508.7772,883.51556 c 0,0 -9.9035,-4.52728 -10.7524,-3.96138 -0.8488,0.56591 -0.8488,54.04438 0.8489,58.57165 3.3954,1.98069 9.6205,-1.98068 9.6205,-1.98068 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:2.82954788" />
+        <path
+           id="path14100"
+           class="st17"
+           d="m 1596.7761,941.80424 c 3.3954,0.84887 6.5079,1.69773 9.6204,3.1125 0.283,5.09319 0,10.46934 -1.1318,15.56251 -6.791,-3.39545 -9.0545,-13.58182 -8.4886,-18.67501 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:2.82954788" />
+        <path
+           id="path14102"
+           class="st17"
+           d="m 1508.7772,941.80424 c -3.3955,0.84887 -6.5081,1.69773 -9.6206,3.1125 -0.2829,5.09319 0,10.46934 1.1318,15.56251 7.074,-3.39545 9.3376,-13.58182 8.4888,-18.67501 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:2.82954788" />
+        <path
+           id="path14076"
+           class="st18"
+           d="m 1500.5714,796.08253 c -0.8488,-7.63978 -4.5273,-37.06708 -3.3954,-45.55573 3.1124,-5.09318 14.7136,-18.39206 26.0319,-19.80683 10.7522,-1.13182 47.8192,-0.84886 59.7034,0 11.8841,2.82954 22.9193,11.31818 27.1636,21.78752 -0.8488,15.84546 -2.8295,34.80344 -3.6784,43.85799 -36.2182,-12.73297 -69.8899,-13.58183 -105.8251,-0.28295 z"
+           inkscape:connector-curvature="0"
+           style="fill:#050405;stroke-width:2.82954788" />
+      </g>
+      <g
+         inkscape:label="Mazda"
+         id="cars_mazda">
+        <path
+           id="path14026"
+           d="m 1329.0406,926.37587 c 2.0875,0 3.8271,2.08758 3.4792,4.17516 0,0 0,0 0,0.34793 v 43.14321 c 0,2.08758 -1.3917,3.47929 -3.4792,3.47929 -2.0877,0 -3.4794,-1.39171 -3.4794,-3.47929 v 0 -43.14321 c -0.3479,-2.43551 1.0438,-4.52309 3.4794,-4.52309 -0.348,0 -0.348,0 0,0 z"
+           inkscape:connector-curvature="0"
+           style="stroke-width:3.4792912" />
+        <path
+           id="path14028"
+           d="m 1325.9092,787.55215 c 2.0876,0 3.4793,1.73965 3.4793,3.82722 v 38.62013 c 0,2.08758 -1.3917,3.47929 -3.4793,3.47929 -2.0876,0 -3.4793,-1.39171 -3.4793,-3.47929 v 0 -38.62013 c -0.3479,-2.08757 1.0438,-3.82722 3.4793,-3.82722 z"
+           inkscape:connector-curvature="0"
+           style="stroke-width:3.4792912" />
+        <path
+           id="path14030"
+           d="m 1437.9423,926.37587 c 2.0876,0 3.8273,2.08758 3.4794,4.17516 0,0 0,0 0,0.34793 v 43.14321 c 0,2.08758 -1.3918,3.47929 -3.4794,3.47929 -2.0875,0 -3.4793,-1.39171 -3.4793,-3.47929 v 0 -43.14321 c -0.3479,-2.43551 1.0439,-4.52309 3.4793,-4.52309 -0.3479,0 -0.3479,0 0,0 z"
+           inkscape:connector-curvature="0"
+           style="stroke-width:3.4792912" />
+        <path
+           id="path14032"
+           d="m 1441.0738,787.55215 c 2.0875,0 3.4792,1.73965 3.4792,3.82722 v 38.62013 c 0,2.08758 -1.3917,3.47929 -3.4792,3.47929 -2.0877,0 -3.4794,-1.39171 -3.4794,-3.47929 v 0 -38.62013 c -0.3479,-2.08757 1.0438,-3.82722 3.4794,-3.82722 z"
+           inkscape:connector-curvature="0"
+           style="stroke-width:3.4792912" />
+        <path
+           id="path14022"
+           class="st0"
+           d="m 1452.2075,845.30839 c 0.3479,-2.08757 0,-4.17515 -0.3479,-5.9148 -3.1314,-3.13136 -7.3066,-4.87101 -11.8297,-4.87101 -0.3479,2.43551 -0.3479,4.87101 0,7.65445 3.8272,0.69585 12.1776,3.13136 12.1776,3.13136 z"
+           inkscape:connector-curvature="0"
+           style="fill:#231f26;stroke-width:3.4792912" />
+        <path
+           id="path14024"
+           class="st0"
+           d="m 1313.3837,845.30839 c -0.3479,-2.08757 0,-4.17515 0.348,-5.9148 3.1314,-3.13136 7.3064,-4.87101 11.8295,-4.87101 0.348,2.43551 0.348,4.87101 0,7.65445 -3.4792,0.69585 -12.1775,3.13136 -12.1775,3.13136 z"
+           inkscape:connector-curvature="0"
+           style="fill:#231f26;stroke-width:3.4792912" />
+        <path
+           id="path14034"
+           class="st0"
+           d="m 1324.1695,762.15333 c 0,-5.91481 23.3113,-22.6154 32.0096,-22.6154 h 53.2331 c 13.9171,0 33.4012,18.09232 32.7053,23.65918 0,4.17515 -4.871,205.97406 -5.2189,212.5847 -3.4794,14.61303 -28.1823,20.87575 -53.9291,20.87575 -28.5302,0 -51.8414,-7.65443 -53.2331,-20.87575 -0.3479,-9.74201 -5.5669,-208.06162 -5.5669,-213.62848 z"
+           inkscape:connector-curvature="0"
+           style="fill:#231f26;stroke-width:3.4792912" />
+        <path
+           id="path14042"
+           class="st2"
+           d="m 1328.6926,762.15333 c 1.3917,-4.87102 11.8296,-16.35267 23.3113,-20.1799 -3.4794,3.13137 -1.3917,2.4355 -4.871,4.87102 -5.9148,3.82721 -11.1338,8.69822 -15.309,14.26509 -1.0437,0.34793 -2.0875,0.69585 -3.1313,1.04379 z"
+           inkscape:connector-curvature="0"
+           style="fill:#ffffa6;stroke-width:3.4792912" />
+        <path
+           id="path14044"
+           class="st2"
+           d="m 1437.2465,762.15333 c -1.3917,-4.87102 -11.8296,-16.35267 -23.3112,-20.1799 3.4792,3.13137 1.3917,2.4355 4.871,4.87102 5.9148,3.82721 11.1337,8.69822 15.3088,14.26509 1.0439,0.34793 2.0876,0.69585 3.1314,1.04379 z"
+           inkscape:connector-curvature="0"
+           style="fill:#ffffa6;stroke-width:3.4792912" />
+        <path
+           id="path14046"
+           class="st17"
+           d="m 1344.3494,958.03743 c 13.2213,4.52308 27.1385,6.61065 41.4036,6.61065 16.0048,0 26.4427,-2.78343 35.4887,-8.00237 5.5669,10.43788 6.6107,18.78818 2.4356,25.0509 -11.8297,10.08995 -28.8782,11.48166 -37.2284,11.82959 -8.3504,0.34793 -33.4013,-0.69585 -44.1871,-13.56923 -3.1313,-6.61066 -3.1313,-12.17753 2.0876,-21.91954 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:3.4792912" />
+        <path
+           id="path14048"
+           class="st17"
+           d="m 1333.9116,822.34507 c 16.0046,-6.26273 33.0532,-9.39409 50.1018,-9.39409 17.3964,0.34793 27.8342,2.78343 48.71,9.04615 -4.871,15.30888 -11.4817,27.13847 -12.8733,38.62014 -1.7397,3.13136 -18.4403,-2.43551 -33.7492,-2.43551 -12.8733,0 -25.7468,1.39172 -38.2722,3.4793 -3.8273,-15.65681 -12.5254,-28.18227 -13.9171,-39.31599 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:3.4792912" />
+        <path
+           id="path14050"
+           class="st17"
+           d="m 1437.2465,840.43738 c 0,11.48166 -2.0875,74.1089 -2.0875,74.1089 l -10.09,-2.4355 c 0,0 -0.6958,-38.2722 0,-50.44972 1.0438,-8.3503 5.5669,-16.00474 12.1775,-21.22368 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:3.4792912" />
+        <path
+           id="path14052"
+           class="st17"
+           d="m 1328.6926,840.43738 c 0,11.48166 2.7834,74.1089 2.7834,74.1089 l 9.7421,-2.4355 c 0,0 0.6958,-38.2722 0,-50.44972 -1.0438,-8.3503 -5.5669,-16.00474 -12.5255,-21.22368 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:3.4792912" />
+        <path
+           id="path14054"
+           class="st17"
+           d="m 1424.7211,917.67765 c 3.1313,0.69585 5.9148,2.08758 9.0461,3.47929 0.3479,5.9148 0,11.48167 -1.0438,17.39646 -6.6106,-3.82723 -8.6982,-14.96095 -8.0023,-20.87575 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:3.4792912" />
+        <path
+           id="path14056"
+           class="st17"
+           d="m 1341.566,917.67765 c -3.1314,0.69585 -5.9148,2.08758 -9.0462,3.47929 -0.3479,5.9148 0,11.48167 1.0439,17.39646 6.6106,-3.82723 8.3502,-14.96095 8.0023,-20.87575 z"
+           inkscape:connector-curvature="0"
+           style="fill:#5b5a5b;stroke-width:3.4792912" />
+        <path
+           id="path14036"
+           class="st18"
+           d="m 1333.5637,819.2137 c -0.696,-8.69822 -4.1752,-41.40356 -3.1314,-50.79765 2.7833,-5.9148 13.5691,-20.17989 24.355,-21.91954 18.4403,-1.04379 37.2284,-1.04379 55.6686,0 11.8296,3.47929 21.2237,12.52545 25.3989,24.00712 -1.0438,17.39645 -2.4356,38.62012 -3.4793,49.058 -33.7491,-14.2651 -65.0627,-15.30888 -98.8118,-0.34793 z"
+           inkscape:connector-curvature="0"
+           style="fill:#050405;stroke-width:3.4792912" />
+      </g>
+    </g>
+    <g
+       id="sensor.garage_door_status"
+       inkscape:label="Garage Door"
+       class="slider vertical">
+      <rect
+         style="fill:#939393"
+         height="42.356377"
+         width="327.49866"
+         y="1012.5446"
+         x="1307.4901"
+         id="garage_door-2"
+         inkscape:label="Rect"
+         class="fill" />
+      <path
+         style="fill:#616262"
+         inkscape:connector-curvature="0"
+         d="m 1305.9202,1012.5447 v -50.8846 h 1.57 v 50.8846 h 326.2426 v -51.1688 h 1.57 l -0.314,76.1846 v 17.3406 h -146.0085 v 3.9798 c 0,0.5685 -0.628,0.8527 -0.942,0.8527 v 0 h -33.9116 c -0.628,0 -0.942,-0.5685 -0.942,-0.8527 v 0 -3.9798 h -147.5785 v -42.3564 z m 1.57,32.4068 h 325.9286 v -14.4977 h -325.9286 z m 0,-30.9855 v 15.0664 h 325.9286 v -15.0664 z m 146.9505,44.3462 h 32.9696 v -3.4111 h -32.9696 z m 178.9781,-4.8325 v -7.1068 h -325.9286 v 7.1068 z"
+         id="garage_door-1"
+         inkscape:label="Path" />
+    </g>
+    <g
+       id="main_doors"
+       inkscape:label="Doors">
+      <rect
+         class=" origin-tl door"
+         inkscape:label="#3068 Door Outside Garage"
+         y="610.97778"
+         x="1689.7361"
+         height="63"
+         width="7"
+         id="sensor.door_garage_outside"
+         style="fill:#00adee" />
+      <rect
+         class="origin-tr door"
+         inkscape:label="#3068 Door Garage Entry"
+         y="569.37244"
+         x="1304.46"
+         height="7"
+         width="63"
+         id="sensor.door_garage_entry"
+         style="fill:#00adee" />
+      <rect
+         class="origin-tr door"
+         inkscape:label="#3068 Door Front"
+         style="fill:#00adee"
+         id="sensor.door_front"
+         width="63"
+         height="7"
+         x="1160.1865"
+         y="569.39722" />
+      <rect
+         class="origin-bl door ccw"
+         style="fill:#00adee"
+         id="sensor.door_entry_closet"
+         width="7"
+         height="48"
+         x="1239.705"
+         y="512.30951"
+         inkscape:label="#2468 Door Entry Closet" />
+      <rect
+         class="origin-tl door ccw"
+         style="fill:#00adee"
+         id="sensor.door_pantry"
+         width="48"
+         height="7"
+         x="1395.0732"
+         y="377.32019"
+         inkscape:label="#2468 Door Pantry" />
+      <rect
+         class="origin-bl door d-r"
+         inkscape:label="#2668 Door Bedroom 2"
+         style="fill:#00adee"
+         id="sensor.door_bedroom_2"
+         width="52"
+         height="6.9999995"
+         x="900.17242"
+         y="522.22595" />
+      <rect
+         class="origin-br door d-l"
+         inkscape:label="#2668 Door Bedroom 1"
+         y="522.04047"
+         x="827.61084"
+         height="6.9999995"
+         width="52"
+         id="sensor.door_bedroom_1"
+         style="fill:#00adee" />
+      <rect
+         class="origin-tr door"
+         style="fill:#00adee"
+         id="sensor.door_bathroom_1_closet"
+         width="41"
+         height="7"
+         x="787.83118"
+         y="452.71646"
+         inkscape:label="#2468 Door Bathroom 1 Closet" />
+      <rect
+         class="origin-bl door ccw"
+         inkscape:label="#2668 Door Bathroom 1"
+         y="394.17581"
+         x="834.13538"
+         height="52"
+         width="7"
+         id="sensor.door_bathroom_1"
+         style="fill:#00adee" />
+      <rect
+         class="origin-tr door"
+         inkscape:label="#2668 Door Bedroom M"
+         y="363.71915"
+         x="861.69885"
+         height="7"
+         width="52"
+         id="sensor.door_bedroom_m"
+         style="fill:#00adee" />
+      <rect
+         class="origin-tr door ccw"
+         style="fill:#00adee"
+         id="sensor.door_bedroom_m_closet"
+         width="7"
+         height="48"
+         x="924.45392"
+         y="256.10138"
+         inkscape:label="#2468 Door Bedroom M Closet" />
+      <rect
+         class="origin-br door"
+         style="fill:#00adee"
+         id="sensor.door_bathroom_m"
+         width="7"
+         height="52"
+         x="924.41669"
+         y="117.60164"
+         inkscape:label="#2668 Door Bathroom M" />
+      <rect
+         class="slider vertical"
+         inkscape:label="#3068 P Door Laundry"
+         y="500.96936"
+         x="1375.1101"
+         height="62"
+         width="5"
+         id="sensor.laundry_door_sensor"
+         style="fill:#00adee" />
+      <rect
+         class="slider horizontal"
+         inkscape:label="Back Door"
+         y="27.815399"
+         x="1516.6873"
+         height="7.4000001"
+         width="63"
+         id="sensor.door_back"
+         style="fill:#00adee" />
+    </g>
+    <g
+       id="main_windows"
+       inkscape:label="Windows">
+      <rect
+         inkscape:label="sensor.window_garage"
+         y="785.74542"
+         x="1689.761"
+         height="83.599998"
+         width="10.7"
+         id="sensor.window_garage"
+         style="fill:#29d8c2" />
+      <rect
+         inkscape:label="sensor.window_bedroom_2"
+         y="693.0141"
+         x="964.79999"
+         height="14.4"
+         width="83.599998"
+         id="sensor.window_bedroom_2"
+         style="fill:#29d8c2" />
+      <rect
+         inkscape:label="sensor.window_bedroom_1"
+         y="734.24872"
+         x="717.5412"
+         height="14.4"
+         width="83.599998"
+         id="sensor.window_bedroom_1"
+         style="fill:#29d8c2" />
+      <rect
+         inkscape:label="sensor.window_kitchen"
+         y="281.28723"
+         x="1686.0518"
+         height="62.600002"
+         width="14.4"
+         id="sensor.window_kitchen"
+         style="fill:#29d8c2" />
+      <rect
+         transform="rotate(45)"
+         inkscape:label="sensor.window_dining_room_2"
+         y="-1157.325"
+         x="1195.8052"
+         height="14.400006"
+         width="41.999973"
+         id="sensor.window_dining_room_2"
+         style="fill:#29d8c2" />
+      <rect
+         inkscape:label="sensor.window_dining_room_1"
+         transform="rotate(-45)"
+         y="1076.1155"
+         x="995.47943"
+         height="14.399999"
+         width="42"
+         id="sensor.window_dining_room_1"
+         style="fill:#29d8c2" />
+      <rect
+         inkscape:label="sensor.window_living_room_2"
+         y="61.604858"
+         x="1270.6401"
+         height="14.4"
+         width="73"
+         id="sensor.window_living_room_2"
+         style="fill:#29d8c2" />
+      <rect
+         inkscape:label="sensor.window_living_room_1"
+         y="61.641968"
+         x="1184.8823"
+         height="14.4"
+         width="73"
+         id="sensor.window_living_room_1"
+         style="fill:#29d8c2" />
+      <rect
+         inkscape:label="sensor.window_bathroom_m"
+         y="61.641968"
+         x="1060.8325"
+         height="14.4"
+         width="42.5"
+         id="sensor.window_bathroom_m"
+         style="fill:#29d8c2" />
+      <rect
+         inkscape:label="sensor.window_bedroom_m"
+         y="61.641968"
+         x="738.12756"
+         height="14.4"
+         width="104.3"
+         id="sensor.window_bedroom_m"
+         style="fill:#29d8c2" />
+    </g>
+    <g
+       id="main_lights"
+       inkscape:label="Lights">
+      <g
+         inkscape:label="switch.outside_front_light_switch"
+         id="switch.outside_front_light_switch">
+        <ellipse
+           style="fill:#585959"
+           id="switch.outside_front_light_switch-3"
+           cx="1710.0699"
+           cy="1066.9441"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="switch.outside_front_light_switch-3" />
+        <ellipse
+           style="fill:#585959"
+           id="switch.outside_front_light_switch-2"
+           cx="1230.4537"
+           cy="1066.9441"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="switch.outside_front_light_switch-2" />
+        <ellipse
+           style="fill:#585959"
+           id="switch.outside_front_light_switch-1"
+           cx="1195.3253"
+           cy="626.83234"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="switch.outside_front_light_switch-1" />
+      </g>
+      <ellipse
+         style="fill:#585959"
+         id="switch.outside_side_light_switch"
+         cx="1716.97"
+         cy="688.66644"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.outside_side_light_switch" />
+      <ellipse
+         style="fill:#585959"
+         id="switch.outside_back_light_switch"
+         cx="1440.4177"
+         cy="44.879456"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.outside_back_light_switch" />
+      <g
+         inkscape:label="switch.garage_light_switch"
+         id="switch.garage_light_switch">
+        <ellipse
+           style="fill:#585959"
+           id="switch.garage_light_switch-3"
+           cx="1582.7539"
+           cy="708.19745"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="switch.garage_light_switch-3" />
+        <ellipse
+           style="fill:#585959"
+           id="switch.garage_light_switch-2"
+           cx="1359.063"
+           cy="708.19745"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="switch.garage_light_switch-2" />
+        <ellipse
+           style="fill:#585959"
+           id="switch.garage_light_switch-1"
+           cx="1591.5162"
+           cy="532.0799"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="switch.garage_light_switch-1" />
+      </g>
+      <ellipse
+         style="display:none;fill:#585959"
+         id="switch.bedroom2_light_switch"
+         cx="1016.3233"
+         cy="585.98242"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.bedroom2_light_switch" />
+      <ellipse
+         style="display:none;fill:#585959"
+         id="switch.bedroom1_light_switch"
+         cx="761.47827"
+         cy="625.76654"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.bedroom1_light_switch" />
+      <ellipse
+         style="display:none;fill:#585959"
+         id="switch.bathroom_light_switch-5"
+         cx="764.05304"
+         cy="400.98798"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.bathroom_light_switch" />
+      <g
+         id="switch.hallway_light_switch"
+         inkscape:label="switch.hallway_light_switch">
+        <ellipse
+           style="fill:#585959"
+           id="switch.hallway_light_switch-2"
+           cx="1083.1902"
+           cy="437.48322"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="switch.hallway_light_switch-2" />
+        <ellipse
+           style="fill:#585959"
+           id="switch.hallway_light_switch-1"
+           cx="938.96851"
+           cy="437.48322"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="switch.hallway_light_switch-1" />
+      </g>
+      <ellipse
+         style="display:none;fill:#585959"
+         id="switch.laundry_light_switch"
+         cx="1430.4603"
+         cy="474.21811"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.laundry_light_switch" />
+      <g
+         inkscape:label="light.kitchen_level"
+         id="light.kitchen_level">
+        <ellipse
+           style="fill:#585959"
+           id="light.kitchen_level-6"
+           cx="1623.5563"
+           cy="358.55252"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="light.kitchen_level-6" />
+        <ellipse
+           style="fill:#585959"
+           id="light.kitchen_level-5"
+           cx="1512.4464"
+           cy="358.55252"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="light.kitchen_level-5" />
+        <ellipse
+           style="fill:#585959"
+           id="light.kitchen_level-4"
+           cx="1623.5563"
+           cy="304.31357"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="light.kitchen_level-4" />
+        <ellipse
+           style="fill:#585959"
+           id="light.kitchen_level-3"
+           cx="1512.4464"
+           cy="304.73148"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="light.kitchen_level-3" />
+        <ellipse
+           style="fill:#585959"
+           id="light.kitchen_level-2"
+           cx="1623.5563"
+           cy="250.39925"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="light.kitchen_level-2" />
+        <ellipse
+           style="fill:#585959"
+           id="light.kitchen_level-1"
+           cx="1512.4464"
+           cy="250.39925"
+           rx="12.529028"
+           ry="12.529029"
+           inkscape:label="light.kitchen_level-1" />
+      </g>
+      <ellipse
+         style="fill:#585959"
+         id="switch.dining_room_light_switch"
+         cx="1581.4121"
+         cy="105.27909"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.dining_room_light_switch" />
+      <ellipse
+         style="fill:#585959"
+         id="switch.garage_entry_light_switch"
+         cx="1336.4508"
+         cy="483.57379"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.garage_entry_light_switch" />
+      <ellipse
+         style="fill:#585959"
+         id="switch.front_entry_light_switch"
+         cx="1188.0565"
+         cy="493.31903"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.front_entry_light_switch" />
+      <ellipse
+         style="fill:#585959"
+         id="light.living_room_level"
+         cx="1277.9639"
+         cy="212.26263"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="light.living_room_level" />
+      <rect
+         inkscape:label="light.lamp2_level"
+         ry="6.264514"
+         rx="6.264514"
+         y="91.357819"
+         x="1328.6956"
+         height="25.058056"
+         width="25.058056"
+         id="light.lamp2_level"
+         style="fill:#585959" />
+      <rect
+         style="fill:#585959"
+         id="light.lamp1_level"
+         width="25.058056"
+         height="25.058056"
+         x="1142.1312"
+         y="91.357819"
+         rx="6.264514"
+         ry="6.264514"
+         inkscape:label="light.lamp1_level" />
+      <ellipse
+         style="display:none;fill:#585959"
+         id="switch.closet_master_light_switch"
+         cx="1034.9008"
+         cy="295.89386"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.closet_master_light_switch" />
+      <ellipse
+         style="display:none;fill:#585959"
+         id="switch.bathroom_shower_light_switch"
+         cx="1074.9044"
+         cy="208.60692"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.bathroom_shower_light_switch" />
+      <ellipse
+         style="display:none;fill:#585959"
+         id="switch.bathroom_master_light_switch"
+         cx="993.36646"
+         cy="107.17146"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="switch.bathroom_master_light_switch" />
+      <ellipse
+         style="display:none;fill:#585959"
+         id="light.bedroom_master_level"
+         cx="819.14777"
+         cy="200.2616"
+         rx="12.529028"
+         ry="12.529029"
+         inkscape:label="light.bedroom_master_level" />
+    </g>
+    <g
+       id="main_fans"
+       inkscape:label="Fans"
+       style="display:none">
+      <path
+         style="fill:#585959"
+         inkscape:label="fan_ceiling_living_room"
+         inkscape:connector-curvature="0"
+         d="m 1221.4942,212.11697 a 4.9456688,4.945674 0 1 1 -4.9457,-4.94567 4.9456688,4.945674 0 0 1 4.9457,4.94567 z m 2.4728,-30.79918 c -0.7665,6.03372 -3.6227,13.26677 -7.4185,21.01911 a 1.0880471,1.0880483 0 0 1 -2.1019,-0.32147 v -21.01911 a 1.0509546,1.0509557 0 0 1 1.0757,-1.01387 h 7.4185 a 1.0262263,1.0262274 0 0 1 1.0262,1.3477 m -38.2176,23.36831 a 1.0262263,1.0262274 0 0 0 -1.3477,1.02623 v 7.41851 a 1.0509546,1.0509557 0 0 0 1.0139,1.07568 h 21.019 a 1.0880471,1.0880483 0 0 0 0.3215,-2.10191 c -7.7647,-3.80817 -14.9854,-6.65193 -21.0191,-7.41851 m 23.4919,38.16824 a 1.0262263,1.0262274 0 0 0 1.0263,1.34769 h 7.4185 a 1.0509546,1.0509557 0 0 0 1.0757,-1.01386 v -21.01911 a 1.0880471,1.0880483 0 0 0 -2.102,-0.32147 c -3.8081,7.76471 -6.6519,14.98539 -7.4185,21.01911 m 38.1682,-23.49195 a 1.0262263,1.0262274 0 0 0 1.3477,-1.02623 v -7.41851 a 1.0509546,1.0509557 0 0 0 -1.0138,-1.07568 h -21.0191 a 1.0880471,1.0880483 0 0 0 -0.3215,2.10191 c 7.7647,3.80817 14.9854,6.65193 21.0191,7.41851"
+         id="fan_ceiling_living_room" />
+      <path
+         id="fan_ceiling_bedroom_m"
+         d="m 755.61055,201.90461 a 4.9456688,4.945674 0 1 1 -4.94566,-4.94567 4.9456688,4.945674 0 0 1 4.94566,4.94567 z m 2.47284,-30.79918 c -0.76658,6.03372 -3.6227,13.26677 -7.4185,21.01911 a 1.0880471,1.0880483 0 0 1 -2.10191,-0.32147 v -21.01911 a 1.0509546,1.0509557 0 0 1 1.07568,-1.01387 h 7.4185 a 1.0262263,1.0262274 0 0 1 1.02623,1.3477 m -38.21765,23.36831 a 1.0262263,1.0262274 0 0 0 -1.34769,1.02623 v 7.41851 a 1.0509546,1.0509557 0 0 0 1.01386,1.07568 h 21.01908 a 1.0880471,1.0880483 0 0 0 0.32147,-2.10191 c -7.76469,-3.80817 -14.98536,-6.65193 -21.01908,-7.41851 m 23.49192,38.16824 a 1.0262263,1.0262274 0 0 0 1.02622,1.3477 h 7.41851 a 1.0509546,1.0509557 0 0 0 1.07568,-1.01387 v -21.01911 a 1.0880471,1.0880483 0 0 0 -2.10191,-0.32147 c -3.80817,7.76471 -6.65193,14.98539 -7.4185,21.01911 m 38.1682,-23.49195 a 1.0262263,1.0262274 0 0 0 1.34769,-1.02623 v -7.41851 a 1.0509546,1.0509557 0 0 0 -1.01386,-1.07568 h -21.01909 a 1.0880471,1.0880483 0 0 0 -0.32147,2.10191 c 7.7647,3.80817 14.98537,6.65193 21.01909,7.41851"
+         inkscape:connector-curvature="0"
+         inkscape:label="fan_ceiling_bedroom_m"
+         style="fill:#585959" />
+      <g
+         inkscape:label="fan_laundry"
+         id="fan_laundry">
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 1416.8507,515.21793 c -0.8395,-0.83953 -2.0987,-0.76955 -2.8682,0.2798 -2.1686,3.56769 -1.8188,8.46452 1.2592,11.54259 3.078,3.07794 7.8349,3.63754 11.5425,1.25916 0.9794,-0.69956 1.1193,-2.02871 0.2799,-2.86812 -2.3785,-2.30851 -7.6251,-7.62511 -10.2134,-10.21343 z"
+           id="path1555" />
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 1442.1743,538.58278 c 0.8394,0.83952 2.0986,0.76954 2.8681,-0.27981 2.1686,-3.56768 1.8188,-8.46452 -1.2592,-11.54258 -3.1479,-3.14792 -7.8349,-3.63754 -11.5425,-1.25917 -0.9794,0.69957 -1.1892,1.95874 -0.2798,2.86825 2.3784,2.37837 7.6251,7.62499 10.2134,10.21331 z"
+           id="path1557" />
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 1441.2649,514.23856 c 0.8394,-0.83953 0.7695,-2.09866 -0.2798,-2.86816 -3.5677,-2.16859 -8.4646,-1.81882 -11.5426,1.25919 -3.078,3.07796 -3.6376,7.90494 -1.3291,11.61246 0.6995,0.97937 2.0287,1.11933 2.8681,0.2798 2.3085,-2.23853 7.765,-7.69497 10.2834,-10.28329 z"
+           id="path1559" />
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 1417.9,539.70211 c -0.8395,0.8394 -0.7695,2.09857 0.2798,2.86812 3.5677,2.16855 8.4645,1.81877 11.5425,-1.25917 3.078,-3.07807 3.6377,-7.83494 1.2592,-11.54259 -0.6995,-0.97936 -2.0287,-1.1192 -2.8681,-0.2798 -2.2386,2.23854 -7.6251,7.62512 -10.2134,10.21344 z"
+           id="path1561" />
+      </g>
+      <g
+         inkscape:label="fan_kitchen"
+         id="fan_kitchen">
+        <path
+           id="path1238-8"
+           d="m 1630.027,251.75338 c -0.8394,-0.83945 -2.0986,-0.76951 -2.8681,0.27982 -2.1686,3.5677 -1.8188,8.46452 1.2592,11.54253 3.078,3.07801 7.8349,3.63765 11.5425,1.25918 0.9794,-0.69954 1.1193,-2.02869 0.2798,-2.86814 -2.3784,-2.3085 -7.625,-7.62507 -10.2134,-10.21339 z"
+           inkscape:connector-curvature="0"
+           style="fill:#585959" />
+        <path
+           id="path1240-6"
+           d="m 1655.3506,275.11826 c 0.8395,0.83946 2.0987,0.76951 2.8682,-0.27982 2.1686,-3.56768 1.8188,-8.46452 -1.2592,-11.54253 -3.148,-3.14796 -7.8349,-3.63764 -11.5425,-1.25918 -0.9794,0.69955 -1.1893,1.95873 -0.2798,2.86814 2.3784,2.37846 7.625,7.62507 10.2133,10.21339 z"
+           inkscape:connector-curvature="0"
+           style="fill:#585959" />
+        <path
+           id="path1242-7"
+           d="m 1654.4412,250.77402 c 0.8395,-0.83946 0.7695,-2.09865 -0.2798,-2.86815 -3.5677,-2.16859 -8.4645,-1.81882 -11.5425,1.25918 -3.078,3.07802 -3.6377,7.9049 -1.3292,11.6125 0.6996,0.97936 2.0287,1.11926 2.8682,0.27981 2.3085,-2.23855 7.765,-7.69502 10.2833,-10.28334 z"
+           inkscape:connector-curvature="0"
+           style="fill:#585959" />
+        <path
+           id="path1244-8"
+           d="m 1631.0764,276.23754 c -0.8395,0.83945 -0.7696,2.09864 0.2798,2.86814 3.5677,2.16859 8.4645,1.81882 11.5425,-1.25918 3.078,-3.07801 3.6376,-7.83494 1.2592,-11.54253 -0.6996,-0.97937 -2.0287,-1.11929 -2.8682,-0.27982 -2.2385,2.23855 -7.625,7.62507 -10.2133,10.21339 z"
+           inkscape:connector-curvature="0"
+           style="fill:#585959" />
+      </g>
+      <g
+         inkscape:label="fan_bathroom"
+         id="fan_bathroom">
+        <path
+           id="path1238"
+           d="m 698.16781,388.75055 c -0.83946,-0.83945 -2.09864,-0.7695 -2.86815,0.27982 -2.16859,3.5677 -1.81882,8.46452 1.25919,11.54253 3.07801,3.07801 7.83493,3.63765 11.54253,1.25919 0.97937,-0.69955 1.11928,-2.0287 0.27982,-2.86815 -2.37846,-2.3085 -7.62507,-7.62507 -10.21339,-10.21339 z"
+           inkscape:connector-curvature="0"
+           style="fill:#585959" />
+        <path
+           id="path1240"
+           d="m 723.49142,412.11543 c 0.83946,0.83946 2.09864,0.76951 2.86814,-0.27982 2.1686,-3.56768 1.81883,-8.46452 -1.25918,-11.54253 -3.14796,-3.14796 -7.83493,-3.63764 -11.54253,-1.25918 -0.97937,0.69955 -1.18923,1.95873 -0.27982,2.86814 2.37846,2.37846 7.62507,7.62507 10.21339,10.21339 z"
+           inkscape:connector-curvature="0"
+           style="fill:#585959" />
+        <path
+           id="path1242"
+           d="m 722.58201,387.77119 c 0.83946,-0.83946 0.7695,-2.09865 -0.27982,-2.86815 -3.56769,-2.16859 -8.46452,-1.81882 -11.54253,1.25918 -3.07801,3.07802 -3.63765,7.9049 -1.32914,11.6125 0.69955,0.97936 2.02869,1.11926 2.86814,0.27981 2.30851,-2.23855 7.76498,-7.69502 10.28335,-10.28334 z"
+           inkscape:connector-curvature="0"
+           style="fill:#585959" />
+        <path
+           id="path1244"
+           d="m 699.21713,413.23471 c -0.83946,0.83945 -0.7695,2.09864 0.27982,2.86814 3.56769,2.16859 8.46452,1.81882 11.54253,-1.25918 3.078,-3.07801 3.63764,-7.83494 1.25918,-11.54253 -0.69954,-0.97937 -2.02868,-1.11928 -2.86814,-0.27982 -2.23855,2.23855 -7.62507,7.62507 -10.21339,10.21339 z"
+           inkscape:connector-curvature="0"
+           style="fill:#585959" />
+      </g>
+      <g
+         inkscape:label="fan_bathroom_m"
+         id="fan_bathroom_m">
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 1066.5683,112.02523 c -0.8395,-0.83945 -2.0987,-0.76951 -2.8682,0.27981 -2.1686,3.5677 -1.8188,8.46453 1.2592,11.54254 3.078,3.078 7.8349,3.63764 11.5425,1.25918 0.9794,-0.69954 1.1193,-2.02869 0.2798,-2.86814 -2.3784,-2.30851 -7.625,-7.62507 -10.2133,-10.21339 z"
+           id="path1216" />
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 1091.8919,135.3901 c 0.8394,0.83947 2.0986,0.76951 2.8681,-0.27981 2.1686,-3.56769 1.8188,-8.46452 -1.2592,-11.54254 -3.1479,-3.14795 -7.8349,-3.63764 -11.5425,-1.25918 -0.9794,0.69956 -1.1892,1.95874 -0.2798,2.86815 2.3784,2.37846 7.625,7.62506 10.2134,10.21338 z"
+           id="path1218" />
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 1090.9825,111.04586 c 0.8394,-0.83945 0.7695,-2.09864 -0.2799,-2.86814 -3.5677,-2.16859 -8.4645,-1.81882 -11.5425,1.25918 -3.078,3.07801 -3.6376,7.90489 -1.3291,11.61249 0.6995,0.97937 2.0287,1.11927 2.8681,0.27982 2.3085,-2.23855 7.765,-7.69503 10.2834,-10.28335 z"
+           id="path1220" />
+        <path
+           style="fill:#585959"
+           inkscape:connector-curvature="0"
+           d="m 1067.6176,136.50938 c -0.8395,0.83946 -0.7695,2.09865 0.2798,2.86815 3.5677,2.16859 8.4645,1.81882 11.5425,-1.25918 3.078,-3.07802 3.6377,-7.83494 1.2592,-11.54254 -0.6995,-0.97937 -2.0287,-1.11928 -2.8681,-0.27981 -2.2386,2.23855 -7.6251,7.62506 -10.2134,10.21338 z"
+           id="path1222" />
+      </g>
+    </g>
+    <g
+       id="main_devices"
+       inkscape:label="Devices">
+      <path
+         id="media_player.onkyo_receiver"
+         d="m 1265.7303,466.32604 c -1.1936,7e-5 -2.3383,0.47437 -3.1821,1.31853 -0.8439,0.84415 -1.3177,1.98898 -1.3174,3.18257 -4e-4,1.19361 0.4735,2.33847 1.3173,3.18264 0.8439,0.84417 1.9886,1.31849 3.1822,1.31856 1.1937,7e-5 2.3385,-0.47417 3.1824,-1.31836 0.844,-0.84419 1.3179,-1.98914 1.3176,-3.18284 3e-4,-1.19369 -0.4736,-2.3386 -1.3176,-3.18277 -0.844,-0.84417 -1.9888,-1.3184 -3.1824,-1.31833 m 0,12.0012 c -1.9891,-5e-5 -3.8967,-0.79028 -5.3031,-2.19683 -1.4064,-1.40656 -2.1964,-3.31421 -2.1963,-5.30327 -10e-5,-1.98903 0.79,-3.89663 2.1964,-5.30314 1.4064,-1.40651 3.3139,-2.19671 5.303,-2.19676 1.989,2e-5 3.8966,0.79021 5.303,2.19672 1.4064,1.40652 2.1965,3.31413 2.1964,5.30318 10e-5,1.98908 -0.7899,3.89675 -2.1963,5.3033 -1.4065,1.40656 -3.3141,2.19678 -5.3031,2.1968 m 0,-24.0023 c 1.6564,-1e-4 2.9994,1.34244 3,2.9989 0,0.79644 -0.3143,1.56069 -0.8771,2.12428 -0.5627,0.5636 -1.3265,0.88027 -2.1229,0.88022 -1.665,0 -3.0001,-1.3492 -3.0001,-3.0045 0,-1.661 1.3351,-2.9989 3.0001,-2.9989 m 7.4994,-2.9988 c 0,0 -14.9988,0 -14.9988,0 -1.6649,0 -3,1.3378 -3,2.9988 0,0 0,24.0023 0,24.0023 5e-4,1.65649 1.3436,2.99903 3,2.9989 0,0 14.9988,0 14.9988,0 1.6565,1.1e-4 2.9995,-1.34243 3,-2.9989 0,0 0,-24.0023 0,-24.0023 0,-1.661 -1.3498,-2.9988 -3,-2.9988 0,0 0,0 0,0"
+         style="fill:#d4ff2a"
+         inkscape:connector-curvature="0" />
+      <g
+         inkscape:label="sensor.device_echo_dot_living_room"
+         id="sensor.device_echo_dot_living_room">
+        <path
+           id="path8542"
+           d="m 1264.2394,414.22777 c 1.1442,0 2.423,-0.28692 2.423,-0.83869 0,-0.55177 -1.2788,-0.88284 -2.423,-0.88284 -1.1442,0 -2.423,0.28692 -2.423,0.83869 0,0.55177 1.3012,0.88284 2.423,0.88284 z m 0,-1.30218 c 1.2788,0 1.9518,0.33106 1.9518,0.41934 -0.045,0.13243 -0.7179,0.41935 -1.9518,0.41935 -1.2788,0 -1.9519,-0.33106 -1.9519,-0.41935 0.022,-0.0883 0.6731,-0.41934 1.9519,-0.41934 z"
+           inkscape:connector-curvature="0"
+           style="fill:#d4ff2a;stroke-width:0.22252241" />
+        <path
+           id="path8544"
+           d="m 1273.8192,414.22777 c 1.1442,0 2.423,-0.28692 2.423,-0.83869 0,-0.55177 -1.2788,-0.88284 -2.423,-0.88284 -1.1442,0 -2.423,0.28692 -2.423,0.83869 0,0.55177 1.2788,0.88284 2.423,0.88284 z m 0,-1.30218 c 1.2788,0 1.9518,0.33106 1.9518,0.41934 -0.045,0.13243 -0.7179,0.41935 -1.9518,0.41935 -1.2788,0 -1.9519,-0.33106 -1.9967,-0.41935 0.045,-0.0883 0.7179,-0.41934 1.9967,-0.41934 z"
+           inkscape:connector-curvature="0"
+           style="fill:#d4ff2a;stroke-width:0.22252241" />
+        <path
+           style="fill:#d4ff2a;stroke-width:0.22252241"
+           inkscape:connector-curvature="0"
+           d="m 1269.1302,409.85775 c -1.0544,0 -9.9612,0.0883 -9.9612,3.53133 v 5.8929 c 0,3.44304 8.9516,3.53132 9.9388,3.53132 0.9871,0 9.9388,-0.0883 9.9388,-3.53132 v -5.93705 c 0.022,-3.3989 -8.9292,-3.48718 -9.9164,-3.48718 z m 8.6151,9.35802 c 0,1.01525 -3.5447,2.14086 -8.5702,2.14086 -5.0255,0 -8.5702,-1.12561 -8.5702,-2.14086 v -3.90654 c 1.3685,0.79455 4.2178,1.5891 8.5702,1.5891 3.971,0 6.7306,-0.55177 8.5702,-1.67738 z m 0,-4.50245 c -1.7948,1.2139 -4.5543,1.76567 -8.5702,1.76567 -4.5543,0 -7.4485,-0.88284 -8.5702,-1.67738 v -0.59592 c 1.2339,1.16976 4.9806,1.76567 8.5702,1.76567 3.5896,0 7.3363,-0.59591 8.5702,-1.76567 z m -8.5253,0.83869 c -5.0255,0 -8.5703,-1.16975 -8.5703,-2.18501 0,-1.01525 3.4999,-2.185 8.5703,-2.185 5.0703,0 8.5702,1.14768 8.5702,2.16293 0,1.01526 -3.5448,2.20708 -8.5702,2.20708 z"
+           id="path8548" />
+      </g>
+      <g
+         id="media_player.plex_shield_living_room"
+         inkscape:label="media_player.plex_shield_living_room">
+        <path
+           d="m 1148.2108,255.93089 h -0.6136 v 4.06718 c 0,0.1985 0.094,0.38286 0.2551,0.49879 l 1.7044,1.22716 c 6e-4,0 0,0 0,10e-4 0,0.002 0.01,0.003 0.01,0.005 0.045,0.0317 0.094,0.0554 0.147,0.0735 0.01,0.002 0.012,0.006 0.018,0.008 0,5.6e-4 0,0.002 0,0.002 0.01,0.002 0.014,0.001 0.02,0.003 0.053,0.013 0.1064,0.0232 0.159,0.0232 0,0 0.01,0 0.013,0 l 6.9038,-0.15156 c -0.1007,-0.20754 -0.1991,-0.41 -0.2941,-0.6068 -0.1007,-0.2081 -0.1996,-0.41056 -0.2946,-0.60679 l -5.1604,0.11197 2.0093,-2.98818 0.022,-0.0339 0.9336,-1.39004 v 0 c -0.095,-0.16909 -0.177,-0.3116 -0.2443,-0.41961 -0.042,-0.002 -0.093,-0.003 -0.1504,-0.003 -0.02,0 -0.042,0.002 -0.062,0.002 -0.049,5.6e-4 -0.1,0.002 -0.1504,0.005 -0.2115,0.008 -0.4281,0.0277 -0.6261,0.0509 -0.04,0.005 -0.08,0.01 -0.1187,0.0136 l -0.6351,1.10728 -1.5337,2.28242 v -3.28225 h -0.6135 -0.6136 v 4.09772 l -0.4773,-0.34383 v -3.75389 z"
+           id="path1150"
+           inkscape:connector-curvature="0"
+           style="fill:#d4ff2a;stroke-width:0.56551492" />
+        <path
+           d="m 1161.7407,260.96906 c -0.069,0.22168 -0.1504,0.42753 -0.2431,0.61868 l 7.1826,-0.15609 c 0.063,-10e-4 0.1261,-0.0147 0.1843,-0.0351 0.01,-0.003 0.017,-0.007 0.027,-0.0102 0.055,-0.0215 0.1063,-0.0509 0.1527,-0.086 0.01,-0.007 0.015,-0.0136 0.023,-0.0209 0.045,-0.0379 0.085,-0.0826 0.117,-0.13177 0,-0.006 0.01,-0.0119 0.01,-0.0175 0.03,-0.0515 0.053,-0.10631 0.067,-0.16795 0,-0.003 0,-0.006 0,-0.0108 0,-0.001 0,-0.002 0,-0.003 0.011,-0.0419 0.014,-0.0848 0.014,-0.12951 v -18.65011 -8.28423 c 0,-0.0599 -0.011,-0.11763 -0.028,-0.17248 0,-0.0108 -0.01,-0.0215 -0.01,-0.0317 -0.017,-0.052 -0.042,-0.10179 -0.075,-0.14703 -0.01,-0.008 -0.012,-0.0147 -0.017,-0.0226 -0.034,-0.0424 -0.071,-0.0814 -0.1126,-0.11424 0,-0.003 -0.01,-0.006 -0.012,-0.009 -0.045,-0.0334 -0.097,-0.0582 -0.1516,-0.078 -0.01,-0.002 -0.012,-0.007 -0.017,-0.009 -0.01,-0.002 -0.011,-0.001 -0.015,-0.002 -0.048,-0.0141 -0.097,-0.0249 -0.1499,-0.0271 l -18.7513,-0.8183 c -0.011,0 -0.023,0.002 -0.034,0.002 -0.017,0 -0.035,0.002 -0.053,0.003 -0.015,10e-4 -0.03,10e-4 -0.044,0.003 -0.01,0.002 -0.018,0.005 -0.027,0.007 -0.01,0.002 -0.014,0.003 -0.021,0.006 -0.015,0.004 -0.031,0.007 -0.046,0.0119 -0.02,0.007 -0.04,0.0158 -0.059,0.0243 -0.012,0.006 -0.025,0.0119 -0.037,0.0192 -0.01,0.005 -0.019,0.008 -0.028,0.0136 0,5.7e-4 0,5.7e-4 0,0.001 v 5.7e-4 c -0.035,0.022 -0.068,0.0475 -0.099,0.0769 v 0 0 l -1.705,1.6366 c -0.1199,0.11593 -0.1883,0.2754 -0.1883,0.44279 v 7.9257 h 0.6136 0.6136 v -7.66273 l 0.4773,-0.45807 v 8.12249 h 0.6136 0.6135 v -8.57999 l 0.2313,0.1131 10.6996,6.3841 -2.5194,4.39349 c 0.093,0.11762 0.1702,0.24769 0.2143,0.39133 l 0.095,0.30086 0.1301,0.41169 0.2364,0.74818 0.2364,0.74761 4.5275,-6.73641 3.6724,1.75309 v 17.27026 l -5.978,-2.978 c 0.012,0.23073 0.022,0.46372 0.028,0.69898 0.01,0.22903 0.01,0.45976 0,0.68823 l 4.0621,2.02341 -4.2691,0.0927 c -0.045,0.21603 -0.098,0.42075 -0.1589,0.61811 z m 5.7513,-26.52208 -3.5169,4.79726 -11.1407,-5.43686 z m 0.561,1.31143 v 5.43742 l -2.9537,-1.40983 z"
+           id="path1152"
+           inkscape:connector-curvature="0"
+           style="fill:#d4ff2a;stroke-width:0.56551492" />
+        <path
+           d="m 1137.358,253.31142 c -0.1137,0.68484 -1.0654,6.7466 0.4615,8.54663 0.3296,0.38908 0.76,0.59436 1.2452,0.59436 0.4389,0 1.4918,-0.0673 1.7927,-0.6871 l 0.034,-0.0701 c 1.9261,-3.9603 3.0543,-6.09172 3.3654,-6.53735 0.061,-0.013 0.1872,-0.0322 0.419,-0.0322 0.7233,0 1.7,0.1787 1.7096,0.1804 0.037,0.007 0.075,0.0107 0.1125,0.0107 h 1.0994 0.6136 0.6135 0.4773 0.6136 0.6136 1.3589 c 0.037,0 0.074,-0.003 0.1109,-0.0107 0.01,-0.001 0.5146,-0.0927 1.075,-0.14025 0.06,-0.006 0.1222,-0.009 0.1821,-0.0124 0.134,-0.009 0.2703,-0.0147 0.3987,-0.0147 0.053,0 0.097,0.002 0.1402,0.003 0.079,0.003 0.146,0.007 0.2002,0.0124 0.076,0.008 0.1307,0.0175 0.1669,0.0266 0.061,0.0826 0.1515,0.22507 0.2686,0.4264 0.4405,0.75722 1.2769,2.36272 2.4883,4.85211 0.096,0.19737 0.1945,0.39926 0.2946,0.60737 0.076,0.15891 0.1532,0.31725 0.233,0.48295 l 0.034,0.0724 c 0.01,0.0181 0.022,0.0351 0.031,0.0526 0.3941,0.67862 1.7938,0.77646 1.8079,0.77646 0.5214,0 0.9784,-0.21942 1.3245,-0.63395 0.056,-0.0662 0.1063,-0.13798 0.1544,-0.21433 0.1159,-0.18096 0.2143,-0.38964 0.2968,-0.62093 0.07,-0.19284 0.1284,-0.39925 0.1771,-0.61754 0,-5.7e-4 0,-5.7e-4 0,-5.7e-4 0.1611,-0.72555 0.2154,-1.58005 0.2098,-2.43963 0,-0.2313 -0.01,-0.46316 -0.015,-0.69389 -0.01,-0.23921 -0.023,-0.47446 -0.039,-0.70576 -0.1092,-1.57157 -0.3478,-2.92428 -0.4038,-3.22513 0,-0.0249 -0.011,-0.0492 -0.017,-0.0741 l -1.5908,-5.03535 -0.2364,-0.74817 -0.2363,-0.74875 -0.1069,-0.33931 -0.2505,-0.79511 -0.014,-0.0447 c -0.028,-0.0854 -0.073,-0.164 -0.1329,-0.23017 l -0.6424,-0.69898 -0.4496,-0.69501 c -0.076,-0.11876 -0.1911,-0.20755 -0.3269,-0.25109 -0.747,-0.24204 -2.5436,-0.8053 -3.0718,-0.8053 -0.5005,0 -1.1565,0.27089 -1.4551,0.40774 h -1.9629 -0.6136 -0.6136 -0.4773 -0.6135 -0.6136 -1.6983 c -0.2935,-0.14025 -0.9235,-0.40774 -1.4601,-0.40774 -0.5882,0 -2.5041,0.61698 -3.0764,0.80643 -0.1335,0.0441 -0.2477,0.13233 -0.3235,0.25052 l -0.4479,0.69502 -0.6424,0.69841 c -0.061,0.0662 -0.1063,0.14477 -0.1335,0.23073 l -2.4368,7.71136 c -0.011,0.0283 -0.018,0.0566 -0.023,0.0854 z m 1.2034,0.24261 2.3825,-7.53944 0.5859,-0.63734 c 0.024,-0.0254 0.045,-0.0537 0.064,-0.0826 l 0.3579,-0.55591 c 1.0389,-0.33591 2.2321,-0.67409 2.4866,-0.67748 0.2635,0 0.7623,0.19793 1.0326,0.33818 0.059,0.03 0.1222,0.0469 0.1872,0.0577 l 0.2534,0.62546 1.6846,4.15088 0.034,0.0831 c 0.094,0.23129 0.3189,0.38342 0.5689,0.38342 h 0.011 0.6136 0.4773 0.6136 0.3296 c 0.1024,0 0.1974,-0.0311 0.2839,-0.0775 0.125,-0.0656 0.2291,-0.16965 0.2845,-0.30594 l 1.7192,-4.23458 0.2584,-0.6379 c 0.037,-0.0102 0.075,-0.022 0.1091,-0.039 0.2941,-0.14421 0.8206,-0.3444 1.0434,-0.3444 0.2545,0.008 1.4489,0.34723 2.4894,0.67862 l 0.358,0.55477 c 0.019,0.0294 0.04,0.0565 0.063,0.0826 l 0.5853,0.63733 0.3145,0.99135 0.2499,0.79511 0.062,0.19567 0.2363,0.74761 0.2364,0.74874 1.2843,4.06549 c 0.1216,0.6707 0.2364,1.48221 0.3173,2.32483 0.022,0.23639 0.043,0.4756 0.059,0.71594 0.016,0.23582 0.031,0.47108 0.04,0.70463 0.05,1.20342 0,2.33728 -0.2307,3.08715 -0.078,0.25505 -0.1742,0.46825 -0.2946,0.62094 -0.01,0.006 -0.01,0.0136 -0.013,0.0187 -0.1098,0.13233 -0.2223,0.19001 -0.3733,0.19227 0,0 -0.01,-5.6e-4 -0.01,-10e-4 -0.1527,-0.013 -0.5237,-0.10123 -0.7159,-0.18549 -0.02,-0.009 -0.04,-0.0175 -0.054,-0.026 -0.096,-0.20019 -0.19,-0.39247 -0.2817,-0.58022 v 0 c -1.5449,-3.19912 -2.3638,-4.74806 -2.8287,-5.51603 -0.1057,-0.17475 -0.1922,-0.31047 -0.2652,-0.41339 -0.2143,-0.30255 -0.3099,-0.35175 -0.3942,-0.39473 -0.02,-0.0102 -0.043,-0.0153 -0.063,-0.0249 -0.079,-0.0351 -0.1668,-0.0633 -0.263,-0.0865 -0.1125,-0.0283 -0.2369,-0.0498 -0.376,-0.0616 -0.089,-0.009 -0.1855,-0.013 -0.2873,-0.0153 -0.046,-0.002 -0.087,-0.005 -0.1357,-0.005 -0.072,0 -0.1448,0.003 -0.2178,0.005 -0.6825,0.0221 -1.3979,0.13799 -1.6038,0.17475 h -1.3052 -0.6135 -0.6136 -0.4773 -0.6136 -0.6136 -1.0439 c -0.237,-0.0419 -1.1395,-0.19228 -1.877,-0.19228 -0.5474,0 -0.9025,0.0786 -1.1519,0.25731 -0.1765,0.12611 -0.505,0.36249 -3.7172,6.96318 -0.1611,0.056 -0.5259,0.10462 -0.7419,0.10462 -0.091,0 -0.19,-0.0187 -0.3088,-0.15891 -0.8703,-1.0281 -0.5825,-5.13261 -0.1934,-7.51173 z m 12.6466,-8.47141 -0.6786,1.67279 -0.6136,1.51162 -0.084,0.20585 h -0.5304 -0.4773 -0.2115 l -0.4021,-0.99135 -0.6136,-1.51162 -0.3602,-0.88729 -0.2477,-0.61019 h 0.6079 0.6136 0.6136 0.4773 0.6136 0.6135 0.9263 z"
+           id="path1154"
+           inkscape:connector-curvature="0"
+           style="fill:#d4ff2a;stroke-width:0.56551492" />
+        <path
+           d="m 1141.8855,248.76186 h 0.7329 v 0.73347 c 0,0.33931 0.2749,0.61302 0.6136,0.61302 0.3393,0 0.6136,-0.27371 0.6136,-0.61302 v -0.73347 h 0.7329 c 0.3393,0 0.6136,-0.27484 0.6136,-0.61415 0,-0.33931 -0.2743,-0.61359 -0.6136,-0.61359 h -0.7329 v -0.7329 c 0,-0.33931 -0.2743,-0.61359 -0.6136,-0.61359 -0.3387,0 -0.6136,0.27428 -0.6136,0.61359 v 0.7329 h -0.7329 c -0.3387,0 -0.6136,0.27428 -0.6136,0.61359 0,0.33931 0.2749,0.61415 0.6136,0.61415 z"
+           id="path1156"
+           inkscape:connector-curvature="0"
+           style="fill:#d4ff2a;stroke-width:0.56551492" />
+        <circle
+           cx="1145.9177"
+           cy="251.65337"
+           r="1.3917321"
+           id="circle1158"
+           style="fill:#d4ff2a;stroke-width:0.56551492" />
+        <path
+           d="m 1152.5455,253.04507 c 0.1368,0 0.2674,-0.026 0.3919,-0.0628 0.2397,-0.0707 0.4529,-0.20019 0.6198,-0.37776 0.2341,-0.24826 0.3806,-0.58135 0.3806,-0.9512 0,-0.76853 -0.6238,-1.39173 -1.3923,-1.39173 -0.6877,0 -1.256,0.50161 -1.3686,1.15761 -0.012,0.0763 -0.023,0.15326 -0.023,0.23412 0,0.17136 0.036,0.33366 0.092,0.48465 0.1985,0.52932 0.7035,0.90709 1.3002,0.90709 z"
+           id="path1160"
+           inkscape:connector-curvature="0"
+           style="fill:#d4ff2a;stroke-width:0.56551492" />
+        <circle
+           cx="1155.3047"
+           cy="246.80009"
+           r="0.73686588"
+           id="circle1162"
+           style="fill:#d4ff2a;stroke-width:0.56551492" />
+        <circle
+           cx="1155.3047"
+           cy="249.52419"
+           r="0.73743147"
+           id="circle1164"
+           style="fill:#d4ff2a;stroke-width:0.56551492" />
+        <circle
+           cx="1153.9429"
+           cy="248.16243"
+           r="0.73743147"
+           id="circle1166"
+           style="fill:#d4ff2a;stroke-width:0.56551492" />
+        <path
+           d="m 1156.6664,248.89984 c 0,0 0,-5.6e-4 0,-5.6e-4 0.4055,-0.001 0.7341,-0.33139 0.7341,-0.73743 0,-0.13403 -0.038,-0.25788 -0.1013,-0.36646 -0.1278,-0.22055 -0.363,-0.36984 -0.635,-0.36984 -0.4089,0 -0.738,0.32913 -0.738,0.73743 5e-4,0.40547 0.3297,0.73686 0.738,0.73686 z"
+           id="path1168"
+           inkscape:connector-curvature="0"
+           style="fill:#d4ff2a;stroke-width:0.56551492" />
+      </g>
+      <rect
+         style="fill:#d4ff2a"
+         id="sensor.device_sony_tv"
+         width="6.6666665"
+         height="114.44444"
+         x="1116.6499"
+         y="149.42273"
+         inkscape:label="sensor.device_sony_tv" />
+      <g
+         inkscape:label="media_player.plex_shield_bedroom"
+         id="media_player.plex_shield_bedroom">
+        <path
+           style="fill:#d4ff2a;stroke-width:0.56551492"
+           inkscape:connector-curvature="0"
+           id="path2"
+           d="m 898.35885,219.95096 h -0.61358 v 4.06718 c 0,0.1985 0.0944,0.38286 0.25504,0.49879 l 1.70446,1.22716 c 5.7e-4,0 10e-4,0 10e-4,0.001 0.003,0.002 0.007,0.003 0.01,0.005 0.0452,0.0317 0.0944,0.0554 0.14703,0.0735 0.006,0.002 0.0119,0.006 0.0181,0.008 10e-4,5.7e-4 0.002,0.002 0.003,0.002 0.007,0.002 0.0136,0.001 0.0204,0.003 0.0526,0.013 0.10632,0.0232 0.15891,0.0232 0.004,0 0.009,0 0.013,0 l 6.9038,-0.15156 c -0.10066,-0.20754 -0.19906,-0.41 -0.29406,-0.6068 -0.10067,-0.20811 -0.19963,-0.41056 -0.29464,-0.6068 l -5.16032,0.11198 2.00927,-2.98818 0.0221,-0.0339 0.93366,-1.39003 v 0 c -0.095,-0.16909 -0.177,-0.3116 -0.2443,-0.41961 -0.0418,-0.002 -0.0927,-0.003 -0.15043,-0.003 -0.0198,0 -0.0418,0.002 -0.0622,0.002 -0.0492,5.6e-4 -0.0995,0.002 -0.15043,0.005 -0.2115,0.008 -0.42809,0.0277 -0.62602,0.0509 -0.0402,0.005 -0.0803,0.01 -0.11876,0.0136 l -0.63508,1.10728 -1.53367,2.28242 v -3.28225 h -0.61359 -0.61358 v 4.09772 l -0.47729,-0.34383 v -3.75389 z" />
+        <path
+           style="fill:#d4ff2a;stroke-width:0.56551492"
+           inkscape:connector-curvature="0"
+           id="path4"
+           d="m 911.88879,224.98913 c -0.0695,0.22168 -0.15042,0.42753 -0.24317,0.61868 l 7.18261,-0.15609 c 0.0633,-0.001 0.12611,-0.0147 0.18435,-0.0351 0.009,-0.003 0.017,-0.007 0.0266,-0.0102 0.0554,-0.0215 0.10632,-0.0509 0.15269,-0.086 0.008,-0.007 0.0153,-0.0136 0.0232,-0.0209 0.0452,-0.0379 0.0848,-0.0826 0.11706,-0.13176 0.003,-0.006 0.006,-0.0119 0.0102,-0.0175 0.03,-0.0515 0.0532,-0.10631 0.0673,-0.16795 10e-4,-0.003 0.003,-0.006 0.005,-0.0108 0,-0.001 0,-0.002 0,-0.003 0.0108,-0.0419 0.0141,-0.0848 0.0141,-0.1295 v -18.65012 -8.28423 c 0,-0.0599 -0.0113,-0.11762 -0.0277,-0.17248 -0.003,-0.0108 -0.006,-0.0215 -0.0102,-0.0317 -0.0175,-0.052 -0.0419,-0.10179 -0.0747,-0.14703 -0.006,-0.008 -0.0119,-0.0147 -0.017,-0.0226 -0.0339,-0.0424 -0.0707,-0.0814 -0.11254,-0.11424 -0.005,-0.003 -0.008,-0.006 -0.0119,-0.009 -0.0447,-0.0334 -0.0973,-0.0583 -0.15156,-0.078 -0.007,-0.002 -0.0119,-0.007 -0.0175,-0.009 -0.006,-0.002 -0.0107,-10e-4 -0.0147,-0.002 -0.0475,-0.0141 -0.0973,-0.0249 -0.14986,-0.0271 l -18.75134,-0.8183 c -0.0113,0 -0.0226,0.002 -0.0339,0.002 -0.0175,0 -0.0351,0.002 -0.0526,0.003 -0.0147,0.001 -0.03,0.001 -0.0441,0.003 -0.009,0.002 -0.0175,0.005 -0.0266,0.007 -0.007,0.002 -0.0141,0.003 -0.0209,0.006 -0.0153,0.004 -0.0311,0.007 -0.0464,0.0119 -0.0204,0.007 -0.0396,0.0158 -0.0588,0.0243 -0.0124,0.006 -0.0249,0.0119 -0.0373,0.0192 -0.009,0.005 -0.0192,0.008 -0.0277,0.0136 -0.001,5.7e-4 -0.002,5.7e-4 -0.003,0.001 v 5.7e-4 c -0.0351,0.0221 -0.0679,0.0475 -0.099,0.0769 v 0 0 l -1.70503,1.6366 c -0.11989,0.11593 -0.18831,0.2754 -0.18831,0.4428 v 7.92569 h 0.61358 0.61358 v -7.66273 l 0.4773,-0.45807 v 8.1225 h 0.61358 0.61359 v -8.58 l 0.23129,0.11311 10.69954,6.38409 -2.51937,4.39349 c 0.0928,0.11763 0.17022,0.24769 0.21433,0.39134 l 0.095,0.30085 0.13007,0.41169 0.23638,0.74818 0.23639,0.74761 4.52751,-6.73641 3.67246,1.75309 v 17.27026 l -5.97806,-2.978 c 0.0119,0.23073 0.0221,0.46372 0.0277,0.69898 0.006,0.22903 0.008,0.45976 0.005,0.68823 l 4.0621,2.02341 -4.26908,0.0928 c -0.0452,0.21602 -0.0984,0.42074 -0.15891,0.6181 z m 5.75129,-26.52208 -3.51694,4.79726 -11.14064,-5.43686 z m 0.56099,1.31143 v 5.43742 l -2.95368,-1.40983 z" />
+        <path
+           style="fill:#d4ff2a;stroke-width:0.56551492"
+           inkscape:connector-curvature="0"
+           id="path6"
+           d="m 887.50605,217.33149 c -0.11367,0.68484 -1.06543,6.7466 0.46146,8.54663 0.3297,0.38908 0.76006,0.59436 1.24527,0.59436 0.43884,0 1.49183,-0.0673 1.79268,-0.6871 l 0.0345,-0.0701 c 1.92614,-3.9603 3.05434,-6.09172 3.36537,-6.53735 0.0611,-0.013 0.18719,-0.0322 0.41905,-0.0322 0.72329,0 1.69994,0.1787 1.70955,0.1804 0.0373,0.007 0.0746,0.0107 0.11254,0.0107 h 1.09936 0.61358 0.61359 0.47729 0.61359 0.61358 1.35893 c 0.0368,0 0.0741,-0.003 0.11084,-0.0107 0.007,-0.001 0.51462,-0.0927 1.07505,-0.14025 0.0605,-0.006 0.12215,-0.009 0.18209,-0.0124 0.13403,-0.009 0.27032,-0.0147 0.39869,-0.0147 0.0526,0 0.0967,0.002 0.14025,0.003 0.0786,0.003 0.1459,0.007 0.20019,0.0125 0.0763,0.008 0.13064,0.0175 0.16683,0.0266 0.0611,0.0826 0.15156,0.22508 0.26862,0.4264 0.44053,0.75723 1.27693,2.36272 2.48826,4.85212 0.0961,0.19736 0.19454,0.39925 0.29464,0.60736 0.0763,0.15891 0.15325,0.31726 0.23299,0.48295 l 0.0345,0.0724 c 0.009,0.0181 0.0221,0.0351 0.0311,0.0526 0.39416,0.67862 1.79381,0.77645 1.80795,0.77645 0.5214,0 0.97834,-0.21942 1.32444,-0.63394 0.056,-0.0662 0.10631,-0.13798 0.15438,-0.21433 0.11593,-0.18096 0.21433,-0.38964 0.2969,-0.62093 0.0696,-0.19284 0.12837,-0.39926 0.177,-0.61755 0,-5.6e-4 0,-5.6e-4 0,-5.6e-4 0.16117,-0.72556 0.21546,-1.58005 0.20981,-2.43963 0,-0.2313 -0.007,-0.46316 -0.0153,-0.69389 -0.0102,-0.23921 -0.0232,-0.47447 -0.039,-0.70576 -0.10915,-1.57157 -0.34779,-2.92428 -0.40378,-3.22513 -0.005,-0.0249 -0.0113,-0.0492 -0.017,-0.0741 l -1.5908,-5.03535 -0.23638,-0.74817 -0.23639,-0.74875 -0.10688,-0.33931 -0.25052,-0.79511 -0.0141,-0.0447 c -0.0277,-0.0854 -0.0729,-0.164 -0.1329,-0.23016 l -0.64242,-0.69898 -0.44959,-0.69502 c -0.0763,-0.11876 -0.19114,-0.20754 -0.32686,-0.25109 -0.74705,-0.24204 -2.54369,-0.80529 -3.07188,-0.80529 -0.50048,0 -1.15648,0.27088 -1.45507,0.40774 h -1.9629 -0.61359 -0.61358 -0.47729 -0.61359 -0.61358 -1.69824 c -0.29351,-0.14025 -0.92349,-0.40774 -1.46016,-0.40774 -0.58814,0 -2.5041,0.61698 -3.0764,0.80642 -0.13347,0.0441 -0.2477,0.13233 -0.32348,0.25053 l -0.44789,0.69502 -0.64242,0.69841 c -0.0605,0.0662 -0.10632,0.14477 -0.13346,0.23073 l -2.43681,7.71136 c -0.0113,0.0283 -0.0181,0.0565 -0.0226,0.0854 z m 1.20342,0.24261 2.38251,-7.53944 0.58588,-0.63734 c 0.0237,-0.0255 0.0452,-0.0537 0.0645,-0.0826 l 0.35797,-0.5559 c 1.03885,-0.33592 2.23208,-0.67409 2.48657,-0.67749 0.26353,0 0.76231,0.19793 1.03263,0.33818 0.0588,0.03 0.12215,0.0469 0.18718,0.0577 l 0.25335,0.62546 1.68467,4.15088 0.0339,0.0831 c 0.0939,0.2313 0.31895,0.38342 0.56891,0.38342 h 0.0113 0.61358 0.4773 0.61358 0.3297 c 0.10235,0 0.19736,-0.0311 0.28389,-0.0775 0.12497,-0.0656 0.22903,-0.16966 0.28445,-0.30594 l 1.71916,-4.23458 0.25844,-0.6379 c 0.0373,-0.0102 0.0752,-0.0221 0.10915,-0.039 0.29407,-0.14421 0.82056,-0.3444 1.04337,-0.3444 0.25449,0.008 1.44885,0.34723 2.4894,0.67862 l 0.35797,0.55477 c 0.0192,0.0294 0.0401,0.0566 0.0633,0.0826 l 0.58531,0.63733 0.31442,0.99135 0.24996,0.79512 0.0616,0.19567 0.23639,0.74761 0.23638,0.74874 1.28429,4.06548 c 0.12158,0.67071 0.23638,1.48222 0.31725,2.32484 0.0221,0.23638 0.043,0.47559 0.0594,0.71594 0.0164,0.23582 0.0311,0.47107 0.0396,0.70463 0.0498,1.20342 -0.003,2.33727 -0.23073,3.08715 -0.0781,0.25504 -0.17418,0.46824 -0.29464,0.62093 -0.006,0.006 -0.009,0.0136 -0.013,0.0187 -0.10971,0.13233 -0.22225,0.19002 -0.37324,0.19228 -0.002,0 -0.006,-5.7e-4 -0.008,-0.001 -0.15269,-0.013 -0.52367,-0.10123 -0.71594,-0.18549 -0.0198,-0.009 -0.0396,-0.0175 -0.0543,-0.026 -0.0961,-0.20019 -0.19002,-0.39246 -0.28163,-0.58021 v 0 c -1.54499,-3.19912 -2.36385,-4.74807 -2.8287,-5.51604 -0.10576,-0.17474 -0.19228,-0.31046 -0.26523,-0.41339 -0.21433,-0.30255 -0.3099,-0.35175 -0.39416,-0.39473 -0.0198,-0.0102 -0.043,-0.0153 -0.0633,-0.0249 -0.0792,-0.0351 -0.16683,-0.0633 -0.26297,-0.0865 -0.11253,-0.0283 -0.23695,-0.0498 -0.37606,-0.0616 -0.0888,-0.009 -0.18549,-0.013 -0.28729,-0.0153 -0.0464,-0.002 -0.0871,-0.005 -0.13572,-0.005 -0.0718,0 -0.14477,0.003 -0.21772,0.005 -0.68258,0.0221 -1.39796,0.13799 -1.6038,0.17475 h -1.30521 -0.61359 -0.61358 -0.47729 -0.61359 -0.61358 -1.04394 c -0.23695,-0.0418 -1.13951,-0.19228 -1.87695,-0.19228 -0.54741,0 -0.90256,0.0786 -1.15195,0.25731 -0.17644,0.12611 -0.505,0.3625 -3.71713,6.96319 -0.16117,0.056 -0.52593,0.10462 -0.74195,0.10462 -0.0905,0 -0.19002,-0.0187 -0.30878,-0.15891 -0.87032,-1.02811 -0.58248,-5.13262 -0.1934,-7.51174 z m 12.64661,-8.47141 -0.67862,1.67279 -0.61358,1.51162 -0.0837,0.20585 h -0.53045 -0.4773 -0.2115 l -0.40208,-0.99135 -0.61358,-1.51162 -0.36024,-0.88729 -0.24769,-0.61019 h 0.60793 0.61358 0.61358 0.4773 0.61358 0.61359 0.92631 z" />
+        <path
+           style="fill:#d4ff2a;stroke-width:0.56551492"
+           inkscape:connector-curvature="0"
+           id="path8"
+           d="m 892.03357,212.78193 h 0.7329 v 0.73347 c 0,0.33931 0.27484,0.61302 0.61359,0.61302 0.33931,0 0.61358,-0.27371 0.61358,-0.61302 v -0.73347 h 0.73291 c 0.33931,0 0.61358,-0.27484 0.61358,-0.61415 0,-0.33931 -0.27427,-0.61359 -0.61358,-0.61359 h -0.73291 v -0.7329 c 0,-0.33931 -0.27427,-0.61359 -0.61358,-0.61359 -0.33875,0 -0.61359,0.27428 -0.61359,0.61359 v 0.7329 h -0.7329 c -0.33875,0 -0.61359,0.27428 -0.61359,0.61359 0,0.33931 0.27484,0.61415 0.61359,0.61415 z" />
+        <circle
+           style="fill:#d4ff2a;stroke-width:0.56551492"
+           id="circle10"
+           r="1.3917321"
+           cy="215.6734"
+           cx="896.06567" />
+        <path
+           style="fill:#d4ff2a;stroke-width:0.56551492"
+           inkscape:connector-curvature="0"
+           id="path12"
+           d="m 902.69352,217.06514 c 0.13686,0 0.26749,-0.026 0.3919,-0.0628 0.23978,-0.0707 0.45298,-0.2002 0.61981,-0.37777 0.23412,-0.24826 0.38059,-0.58135 0.38059,-0.95119 0,-0.76854 -0.62376,-1.39174 -1.3923,-1.39174 -0.68766,0 -1.25601,0.50162 -1.36854,1.15761 -0.0119,0.0763 -0.0232,0.15326 -0.0232,0.23413 0,0.17135 0.0356,0.33365 0.0916,0.48464 0.1985,0.52932 0.7035,0.90709 1.30012,0.90709 z" />
+        <circle
+           style="fill:#d4ff2a;stroke-width:0.56551492"
+           id="circle14"
+           r="0.73686588"
+           cy="210.82016"
+           cx="905.4527" />
+        <circle
+           style="fill:#d4ff2a;stroke-width:0.56551492"
+           id="circle16"
+           r="0.73743147"
+           cy="213.54424"
+           cx="905.4527" />
+        <circle
+           style="fill:#d4ff2a;stroke-width:0.56551492"
+           id="circle18"
+           r="0.73743147"
+           cy="212.18248"
+           cx="904.09088" />
+        <path
+           style="fill:#d4ff2a;stroke-width:0.56551492"
+           inkscape:connector-curvature="0"
+           id="path20"
+           d="m 906.81443,212.91991 c 10e-4,0 0.002,-5.6e-4 0.002,-5.6e-4 0.40547,-0.001 0.73404,-0.33139 0.73404,-0.73743 0,-0.13403 -0.0379,-0.25788 -0.10123,-0.36646 -0.1278,-0.22055 -0.36306,-0.36984 -0.63507,-0.36984 -0.40887,0 -0.738,0.32912 -0.738,0.73743 5.7e-4,0.40547 0.3297,0.73686 0.738,0.73686 z" />
+      </g>
+    </g>
+  </g>
+  <g
+     inkscape:label="Buttons"
+     id="buttons">
+    <g
+       id="button_toggle_floor"
+       inkscape:label="button_toggle_floor">
+      <rect
+         style="fill:#9a9a9b"
+         id="rect8564-9"
+         width="76.227913"
+         height="61.282589"
+         x="549.1684"
+         y="64.50618"
+         inkscape:label="Background" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2-5"
+         d="m 589.71561,83.64011 2.83066,1.76652 2.03784,-3.26171 -16.41436,-10.26234 -16.41243,10.26042 2.03784,3.2617 2.82874,-1.76459 v 17.45349 h -3.84862 v 17.31878 h 50.03204 V 101.0936 h -23.09171 z m 3.84862,19.3778 v 9.62154 h -13.47017 v -3.84862 h -3.84862 v -3.84861 h -3.84861 v -3.84862 h -3.84862 V 82.43742 l 9.62154,-6.01347 9.62155,6.01347 v 18.65618 h -7.69724 v 1.92431 z"
+         style="stroke-width:1.92430925"
+         inkscape:label="Path" />
+    </g>
+  </g>
+</svg>

--- a/www/custom_ui/floorplan/ha-floorplan.html
+++ b/www/custom_ui/floorplan/ha-floorplan.html
@@ -1,0 +1,948 @@
+<!--
+  Floorplan for Home Assistant
+  Version: 1.0.6
+  https://github.com/pkozul/ha-floorplan
+-->
+
+<script src="lib/jquery-3.2.1.min.js"></script>
+<script src="lib//moment.min.js"></script>
+<script src="lib/svg-pan-zoom.min.js"></script>
+
+<!-- As documented here for chrome, removes the need for touchstart -->
+<meta name="viewport" content="width=device-width">
+
+<dom-module id="ha-floorplan">
+
+  <template>
+    <style>
+      .loading-container {
+        text-align: center;
+        padding: 8px;
+      }
+
+      .loading {
+        height: 0px;
+        overflow: hidden;
+      }
+
+      #errors {
+        color: #FF0000;
+        display: none;
+      }
+
+      #warnings {
+        color: #FF851B;
+        display: none;
+      }
+
+      #debug {
+        color: #000000;
+        display: none;
+      }
+    </style>
+
+    <template is='dom-if' if='[[isLoading]]'>
+      <div class='loading-container'>
+        <paper-spinner active alt='Loading'></paper-spinner>
+      </div>
+    </template>
+
+    <div id="errors">
+      <ul></ul>
+    </div>
+
+    <div id="warnings">
+      <ul></ul>
+    </div>
+
+    <div id="debug">
+      <ul></ul>
+    </div>
+
+    <div id="floorplan" on-tap="stopPropagation"></div>
+
+  </template>
+
+</dom-module>
+
+<script>
+  Polymer({
+    is: 'ha-floorplan',
+
+    ready() {
+    },
+
+    attached() {
+      this.onAttached();
+    },
+
+    detached() {
+    },
+
+    properties: {
+      hass: {
+        type: Object,
+        observer: 'hassChanged'
+      },
+      inDialog: {
+        type: Boolean,
+        value: false,
+      },
+      isPanel: {
+        type: Boolean,
+        value: false,
+      },
+      config: {
+        type: Object,
+      },
+      isLoading: {
+        type: Boolean,
+        value: true,
+      },
+      timeDifference: {
+        type: Number,
+        value: undefined,
+      },
+      entityConfigs: {
+        type: Array,
+        value: () => { return []; },
+      },
+      elementConfigs: {
+        type: Array,
+        value: () => { return []; },
+      },
+      cssRules: {
+        type: Array,
+        value: () => { return []; },
+      },
+    },
+
+    stopPropagation(e) {
+      e.stopPropagation();
+    },
+
+    hassChanged: function (newHass, oldHass) {
+      this.handleEntities(newHass.states);
+    },
+
+    onAttached() {
+      window.onerror = this.handleWindowError.bind(this);
+
+      if (!this.config.groups) {
+        this.isLoading = false;
+        this.warn(`Cannot find 'groups' in floorplan configuration`);
+        return;
+      }
+
+      let invalidGroups = this.config.groups.filter(x => x.entities && x.elements);
+      if (invalidGroups.length) {
+        this.isLoading = false;
+        this.warn(`A group cannot contain both 'entities' and 'elements' in floorplan configuration`);
+        return;
+      }
+
+      invalidGroups = this.config.groups.filter(x => !x.entities && !x.elements);
+      if (invalidGroups.length) {
+        this.isLoading = false;
+        this.warn(`A group must contain either 'entities' or 'elements' in floorplan configuration`);
+        return;
+      }
+
+      this.hass.connection.socket.addEventListener('message', event => {
+        let data = JSON.parse(event.data);
+
+        // Store the time difference between the local web browser and the Home Assistant server
+        if (data.event && data.event.time_fired) {
+          let lastEventFiredTime = moment(data.event.time_fired).toDate();
+          this.timeDifference = moment().diff(moment(lastEventFiredTime), 'milliseconds');
+        }
+      });
+
+      this.addExternalCss(() => {
+        this.loadFloorPlan(() => {
+          this.isLoading = false;
+          this.handleEntities(this.hass.states);
+        });
+      });
+
+      if (this.config.groups.find(entityGroup => entityGroup.state_transitions)) {
+        setInterval(this.updateStateTransitions.bind(this), 100);
+      }
+    },
+
+    handleWindowError(msg, url, lineNo, columnNo, error) {
+      if (msg.toLowerCase().indexOf("script error") >= 0) {
+        this.error('Script error: See browser console for detail');
+      }
+      else {
+        let message = [
+          msg,
+          'URL: ' + url,
+          'Line: ' + lineNo + ', column: ' + columnNo,
+          'Error: ' + JSON.stringify(error)
+        ].join('<br>');
+
+        this.error(message);
+      }
+
+      return false;
+    },
+
+    addExternalCss(callback) {
+      if (!this.config.stylesheet) {
+        callback();
+      }
+
+      this.loadStyleSheet(this.config.stylesheet + '?cacheBuster=' + (new Date().getTime()), function (success, link) {
+        if (success) {
+          Polymer.dom(this.instance.root).appendChild(link);
+          let styleSheet = link['sheet'];
+          this.instance.cssRules = this.instance.getArray(styleSheet.cssRules);
+          callback();
+        }
+        else {
+          this.instance.error("Error loading stylesheet");
+        }
+      }.bind({ instance: this, callback: callback }));
+    },
+
+    loadFloorPlan(callback) {
+      jQuery.ajax({
+        url: this.config.image + '?cacheBuster=' + (new Date().getTime()),
+        success: function (result) {
+          let svg = $(result).find('svg')[0];
+
+          $(svg).height('100%');
+          $(svg).width('100%');
+          $(svg).css('position', this.instance.isPanel ? 'absolute' : 'relative');
+          $(svg).css('cursor', 'default');
+
+          Polymer.dom(this.instance.$.floorplan).node.appendChild(svg);
+
+          let uniqueId = (new Date()).getTime();
+
+          let svgElements = $(svg).find('*').toArray();
+
+          let elementGroups = this.instance.config.groups.filter(x => x.elements);
+          for (let elementGroup of elementGroups) {
+            for (let elementId of elementGroup.elements) {
+              let svgElement = $(svg).find(`[id="${elementId}"]`);
+
+              if (svgElement.length) {
+                $(svgElement).on('click', this.instance.onElementClick.bind({ instance: this.instance, elementId: elementId }));
+                $(svgElement).css('cursor', 'pointer');
+
+                let elementConfig = {
+                  group: elementGroup,
+                };
+
+                this.instance.elementConfigs[elementId] = elementConfig;
+
+                if (elementGroup.action.data.elements) {
+                  for (let otherElementId of elementGroup.action.data.elements) {
+                    let otherSvgElement = $(svg).find(`[id="${otherElementId}"]`);
+                    $(otherSvgElement).addClass(elementGroup.action.data.default_class);
+                  }
+                }
+              }
+              else {
+                this.instance.warn(`Cannot find '${elementId}' in SVG file`);
+              }
+            }
+          }
+
+          let entityGroups = this.instance.config.groups.filter(x => x.entities);
+          for (let entityGroup of entityGroups) {
+            let targetEntityIds = [];
+
+            // Split out HA entity groups into separate entities
+            if (entityGroup.groups) {
+              for (let entityId of entityGroup.groups) {
+                let group = this.instance.hass.states[entityId];
+                if (group) {
+                  for (let targetEntityId of group.attributes.entity_id) {
+                    targetEntityIds.push(targetEntityId);
+                  }
+                }
+                else {
+                  this.instance.warn(`Cannot find '${entityId}' in HA group configuration`);
+                }
+              }
+            }
+
+            // HA entities treated as is
+            if (entityGroup.entities) {
+              for (let entityId of entityGroup.entities) {
+                let entity = this.instance.hass.states[entityId];
+                if (entity) {
+                  targetEntityIds.push(entityId);
+                }
+                else {
+                  this.instance.warn(`Cannot find '${entityId}' in HA group configuration`);
+                }
+              }
+            }
+
+            for (let entityId of targetEntityIds) {
+              let entityConfig = {
+                group: entityGroup,
+                lastState: undefined,
+                lastChangedTime: undefined,
+                svgElementConfigs: {},
+                imageUrl: undefined
+              };
+
+              this.instance.entityConfigs[entityId] = entityConfig;
+
+              let svgElement = svgElements.find(svgElement => svgElement.id === entityId);
+              if (!svgElement) {
+                this.instance.warn(`Cannot find element '${entityId}' in SVG file`);
+                continue;
+              }
+
+              entityConfig.svgElementConfigs[svgElement.id] = {
+                svgElementId: svgElement.id,
+                svgElement: svgElement,
+                clonedsvgElement: svgElement.cloneNode(true),
+                entityId: entityId
+              };
+
+              $(svgElement).find('*').each((i, svgNestedElement) => {
+                // Ensure that all child elements have an Id.
+                if (!svgNestedElement.id) {
+                  svgNestedElement.id = uniqueId++;
+                }
+
+                entityConfig.svgElementConfigs[svgNestedElement.id] = {
+                  svgElementId: svgNestedElement.id,
+                  svgElement: svgNestedElement,
+                  clonedsvgElement: svgNestedElement.cloneNode(true),
+                  entityId: entityId
+                };
+              });
+
+              for (svgElementId in entityConfig.svgElementConfigs) {
+                let svgElementConfig = entityConfig.svgElementConfigs[svgElementId];
+
+                let svgElement = $(svgElementConfig.svgElement);
+
+                // Create a title element (to support hover over text)
+                svgElement.append(document.createElementNS('http://www.w3.org/2000/svg', 'title'));
+
+                if (svgElement.length) {
+                  svgElementConfig.svgElement = svgElement[0];
+
+                  $(svgElement).on('click', this.instance.onEntityClick.bind({ instance: this.instance, entityId: entityId }));
+                  $(svgElement).css('cursor', 'pointer');
+                  $(svgElement).addClass('ha-entity');
+
+                  if ((svgElement[0].nodeName === 'text') && (svgElement[0].id === entityId)) {
+                    let boundingBox = svgElement[0].getBBox();
+                    let rect = $(document.createElementNS("http://www.w3.org/2000/svg", 'rect'))
+                      .attr('id', entityId + '.background')
+                      .attr('height', boundingBox.height + 1)
+                      .attr('width', boundingBox.width + 2)
+                      .height(boundingBox.height + 1)
+                      .width(boundingBox.width + 2)
+                      .attr('x', boundingBox.x - 1)
+                      .attr('y', boundingBox.y - 0.5)
+                      .css('fill-opacity', 0);
+
+                    $(rect).insertBefore($(svgElement));
+                  }
+                }
+              }
+            }
+          }
+
+          // Enable pan / zoom if enabled in config
+          if ((this.instance.config.pan_zoom === null) || (this.instance.config.pan_zoom !== undefined)) {
+            svgPanZoom($(svg)[0], {
+              zoomEnabled: true,
+              controlIconsEnabled: true,
+              fit: true,
+              center: true,
+            });
+          }
+
+          this.callback();
+
+        }.bind({ instance: this, callback: callback })
+      });
+    },
+
+    handleEntities(entities) {
+      let svg = Polymer.dom(this.$.floorplan).querySelector('svg');
+
+      for (let entityId in entities) {
+        let entityState = entities[entityId];
+
+        let entityConfig = this.entityConfigs[entityId];
+        if (!entityConfig)
+          continue;
+
+        entityConfig.lastState = entityState.state;
+
+        for (let svgElementId in entityConfig.svgElementConfigs) {
+          let svgElementConfig = entityConfig.svgElementConfigs[svgElementId];
+          let svgElement = svgElementConfig.svgElement;
+
+          if (!svgElement)
+            continue;
+
+          this.setHoverOverText(svgElement, entityState);
+
+          if (svgElement.nodeName === 'text') {
+            let text = entityConfig.group.text_template ?
+              this.assemble(entityConfig.group.text_template, entityState, entities) : entityState.state;
+
+            let tspan = $(svgElement).find('tspan');
+            if (tspan.length) {
+              $(tspan).text(text);
+            }
+            else {
+              let title = $(svgElement).find('title');
+              $(svgElement).text(text);
+              if (title.length) {
+                $(svgElement).append(title);
+              }
+            }
+
+            let rect = $(svgElement).parent().find(`[id="${entityId}.background"]`);
+            if (rect.length) {
+              let boundingBox = svgElement.getBBox();
+              $(rect)
+                .attr("x", boundingBox.x - 1)
+                .attr("y", boundingBox.y - 0.5)
+                .attr('height', boundingBox.height + 1)
+                .attr('width', boundingBox.width + 2)
+                .height(boundingBox.height + 1)
+                .width(boundingBox.width + 2);
+            }
+          }
+
+          if (!this.cssRules || !this.cssRules.length)
+            return;
+
+          let wasTransitionHandled = false;
+
+          if (entityConfig.group.states && entityConfig.group.state_transitions) {
+            let transitionConfig = entityConfig.group.state_transitions.find(transitionConfig => (transitionConfig.to_state === entityState.state));
+            if (transitionConfig && transitionConfig.from_state && transitionConfig.to_state && transitionConfig.duration) {
+              // Determine the current time on the server (based on the local vs. server time difference)
+              let serverMoment = this.getServerMoment();
+              let lastChangedMoment = moment(entityState.last_changed);
+              let elapsed = Math.max(serverMoment.diff(lastChangedMoment, 'milliseconds'), 0);
+              let remaining = (transitionConfig.duration * 1000) - elapsed;
+
+              if (remaining > 0) {
+                entityConfig.lastChangedTime = lastChangedMoment.toDate();
+              }
+              else {
+                this.setEntityStyle(svgElementConfig, svgElement, entityConfig);
+              }
+              wasTransitionHandled = true;
+            }
+          }
+
+          if (entityConfig.group.image_template) {
+            imageUrl = this.assemble(entityConfig.group.image_template, entityState, entities);
+            if (entityConfig.imageUrl !== imageUrl) {
+              entityConfig.imageUrl = imageUrl;
+              this.loadImage(imageUrl, entityId, entityState, (embeddedSvg, entityState) => {
+                this.setHoverOverText(embeddedSvg, entityState);
+              });
+            }
+
+            let embeddedSvg = $(svg).find(`[id="image.${entityId}"]`)[0];
+            this.setHoverOverText(embeddedSvg, entityState);
+          }
+
+          let targetClass = undefined;
+          let obsoleteClasses = [];
+
+          if (entityConfig.group.class_template) {
+            targetClass = this.assemble(entityConfig.group.class_template, entityState, entities);
+          }
+
+          let originalClasses = this.getArray(svgElementConfig.clonedsvgElement.classList);
+
+          // Get the config for the current state
+          if (entityConfig.group.states) {
+            let stateConfig = entityConfig.group.states.find(stateConfig => (stateConfig.state === entityState.state));
+            if (stateConfig && stateConfig.class && !wasTransitionHandled) {
+              targetClass = stateConfig.class;
+            }
+
+            // Remove any other previously-added state classes
+            for (let otherStateConfig of entityConfig.group.states) {
+              if (!stateConfig || (otherStateConfig.state != stateConfig.state)) {
+                if (otherStateConfig.class && (otherStateConfig.class != 'ha-entity') && $(svgElement).hasClass(otherStateConfig.class)) {
+                  if (originalClasses.indexOf(otherStateConfig.class) < 0) {
+                    obsoleteClasses.push(otherStateConfig.class);
+                  }
+                }
+              }
+            }
+          }
+          else {
+            for (let otherClassName of this.getArray(svgElement.classList)) {
+              if ((otherClassName != targetClass) && (otherClassName != 'ha-entity')) {
+                if (originalClasses.indexOf(otherClassName) < 0) {
+                  obsoleteClasses.push(otherClassName);
+                }
+              }
+            }
+          }
+
+          // Remove any obsolete classes from the entity
+          this.removeClasses(entityId, svgElement, obsoleteClasses);
+
+          // Add the target class to the entity
+          if (targetClass) {
+            this.addClass(entityId, svgElement, targetClass);
+          }
+
+          if (this.config.last_motion_entity && this.config.last_motion_class && entities[this.config.last_motion_entity] &&
+            (entityState.attributes.friendly_name === entities[this.config.last_motion_entity].state)) {
+            if (!$(svgElement).hasClass(this.config.last_motion_class)) {
+              $(svgElement).addClass(this.config.last_motion_class);
+            }
+          }
+          else {
+            if ($(svgElement).hasClass(this.config.last_motion_class)) {
+              $(svgElement).removeClass(this.config.last_motion_class);
+            }
+          }
+        }
+      }
+    },
+
+    setHoverOverText(element, entityState) {
+      let title = $(element).find('title');
+      if (title.length) {
+        let dateFormat = this.config.date_format ? this.config.date_format : 'DD-MMM-YYYY';
+        let titleText = entityState.attributes.friendly_name + '\n' +
+          'State: ' + entityState.state + '\n' +
+          'Last changed date: ' + moment(entityState.last_changed).format(dateFormat) + '\n' +
+          'Last changed time: ' + moment(entityState.last_changed).format('HH:mm:ss');
+
+        $(title).html(titleText);
+      }
+    },
+
+    loadImage(imageUrl, entityId, entityState, callback) {
+      let svg = Polymer.dom(this.$.floorplan).querySelector('svg');
+      jQuery.ajax({
+        url: imageUrl, // allow the browser cache to be used
+        success: function (result) {
+          let svgElement = $(svg).find(`[id="${entityId}"]`);
+          let bbox = svgElement[0].getBBox();
+          let clientRect = svgElement[0].getBoundingClientRect();
+
+          let embeddedSvg = $(result).find('svg');
+
+          embeddedSvg.attr('id', `image.${entityId}`);
+          embeddedSvg.attr('preserveAspectRatio', 'xMinYMin meet')
+          embeddedSvg
+            .attr('height', bbox.height)
+            .attr('width', bbox.width)
+            .attr('x', bbox.x)
+            .attr('y', bbox.y);
+
+          $(embeddedSvg).find('*').append(document.createElementNS('http://www.w3.org/2000/svg', 'title'))
+            .on('click', this.onEntityClick.bind({ instance: this, entityId: entityId }))
+            .css('cursor', 'pointer')
+            .addClass('ha-entity');
+
+          // Remove previous SVG
+          let previousEmbeddedSvg = $(svg).find(`[id="${embeddedSvg.attr('id')}"]`);
+          $(previousEmbeddedSvg).find('*')
+            .off('click')
+            .remove();
+
+          $(svg).append(embeddedSvg);
+
+          callback(embeddedSvg, entityState);
+
+        }.bind(this)
+      });
+    },
+
+    addClass(entityId, svgElement, className) {
+      if ($(svgElement).hasClass('ha-leave-me-alone')) {
+        return;
+      }
+
+      if (!$(svgElement).hasClass(className)) {
+        //console.log(`${entityId}: adding class "${className}" for current state "${entityState.state}" (${svgElement.id})`);
+        $(svgElement).addClass(className);
+
+        if ((svgElement.nodeName === 'text')) {
+          let rect = $(svgElement).parent().find(`[id="${entityId}.background"]`);
+          if (rect.length) {
+            if (!$(rect).hasClass(className + '-background')) {
+              $(rect).addClass(className + '-background');
+            }
+          }
+        }
+      }
+    },
+
+    removeClasses(entityId, svgElement, classes) {
+      for (className of classes) {
+        //console.log(`${entityId}: removing class "${className}" (${svgElement.id})`);
+        if ($(svgElement).hasClass(className)) {
+          $(svgElement).removeClass(className);
+
+          if ((svgElement.nodeName === 'text')) {
+            let rect = $(svgElement).parent().find(`[id="${entityId}.background"]`);
+            if (rect.length) {
+              if ($(rect).hasClass(className + '-background')) {
+                $(rect).removeClass(className + '-background');
+              }
+            }
+          }
+        }
+      }
+    },
+
+    updateStateTransitions() {
+      if (!this.cssRules || !this.cssRules.length)
+        return;
+
+      let svg = Polymer.dom(this.$.floorplan).querySelector('svg');
+
+      for (let entityId in this.entityConfigs) {
+        let entityConfig = this.entityConfigs[entityId];
+
+        if (!entityConfig || !entityConfig.group.states || !entityConfig.group.state_transitions || (entityConfig.lastChangedTime === undefined))
+          continue;
+
+        for (let svgElementId in entityConfig.svgElementConfigs) {
+          let svgElementConfig = entityConfig.svgElementConfigs[svgElementId];
+          let svgElement = svgElementConfig.svgElement;
+
+          if (!svgElement)
+            continue;
+
+          let wasTransitionHandled = false;
+
+          let transitionConfig = entityConfig.group.state_transitions.find(transitionConfig => (transitionConfig.to_state === entityConfig.lastState));
+          if (transitionConfig && transitionConfig.from_state && transitionConfig.to_state && transitionConfig.duration) {
+            let serverMoment = this.getServerMoment();
+            let fromStateConfig = entityConfig.group.states.find(stateConfig => (stateConfig.state === transitionConfig.from_state));
+            let toStateConfig = entityConfig.group.states.find(stateConfig => (stateConfig.state === transitionConfig.to_state));
+
+            if (fromStateConfig && toStateConfig) {
+              let fromFill = this.getFill(fromStateConfig);
+              let toFill = this.getFill(toStateConfig);
+
+              if (fromFill && toFill) {
+                let elapsed = serverMoment.diff(moment(entityConfig.lastChangedTime), 'milliseconds');
+                if (elapsed < 0) {
+                  this.setTransitionFill(svgElement, fromFill, toFill, 1);
+                }
+                else {
+                  if (elapsed < (transitionConfig.duration * 1000)) {
+                    this.setTransitionFill(svgElement, fromFill, toFill, elapsed / (transitionConfig.duration * 1000));
+                  }
+                  else {
+                    this.setTransitionFill(svgElement, fromFill, toFill, 0);
+                    entityConfig.lastChangedTime = undefined;
+                  }
+                }
+
+                wasTransitionHandled = true;
+              }
+            }
+          }
+
+          if (!wasTransitionHandled) {
+            this.setEntityStyle(svgElementConfig, svgElement, entityConfig);
+          }
+        }
+      }
+    },
+
+    setEntityStyle(svgElementConfig, svgElement, entityConfig, state) {
+      let stateConfig = entityConfig.group.states.find(stateConfig => (stateConfig.state === entityConfig.lastState));
+      if (stateConfig) {
+        let stroke = this.getStroke(stateConfig);
+        if (stroke) {
+          svgElement.style.stroke = stroke;
+        }
+        else {
+          if (svgElementConfig.clonedsvgElement) {
+            svgElement.style.stroke = svgElementConfig.clonedsvgElement.style.stroke;
+          }
+          else {
+            // ???
+          }
+        }
+
+        let fill = this.getFill(stateConfig);
+        if (fill) {
+          svgElement.style.fill = fill;
+        }
+        else {
+          if (svgElementConfig.clonedsvgElement) {
+            svgElement.style.fill = svgElementConfig.clonedsvgElement.style.fill;
+          }
+          else {
+            // ???
+          }
+        }
+      }
+    },
+
+    onElementClick(e) {
+      let svgElement = e.target;
+
+      let elementConfig = this.instance.elementConfigs[this.elementId];
+      if (elementConfig.group.action) {
+        let action = elementConfig.group.action;
+        if (action.service) {
+          switch (action.domain) {
+            case 'class':
+
+              switch (action.service) {
+                case 'toggle':
+                  let svg = Polymer.dom(this.instance.$.floorplan).querySelector('svg');
+                  let classes = action.data.classes;
+
+                  for (let otherElementId of action.data.elements) {
+                    let otherSvgElement = $(svg).find(`[id="${otherElementId}"]`);
+
+                    if ($(otherSvgElement).hasClass(classes[0])) {
+                      $(otherSvgElement).removeClass(classes[0]);
+                      $(otherSvgElement).addClass(classes[1]);
+                    }
+                    else if ($(otherSvgElement).hasClass(classes[1])) {
+                      $(otherSvgElement).removeClass(classes[1]);
+                      $(otherSvgElement).addClass(classes[0]);
+                    }
+                    else {
+                      $(otherSvgElement).addClass(action.data.default_class);
+                    }
+                  }
+                  break;
+              }
+              break;
+
+            default:
+              domain = action.domain
+              let data = action.data ? action.data : {};
+              if (action.data_template) {
+                let entities = this.instance.hass.states;
+                let entityState = entities[entityId];
+                let result = this.instance.assemble(action.data_template, entityState, entities);
+                data = JSON.parse(result);
+              }
+              this.instance.hass.callService(domain, action.service, data);
+              break;
+          }
+        }
+      }
+    },
+
+    onEntityClick(e) {
+      let entityId = this.entityId;
+
+      let entityConfig = this.instance.entityConfigs[entityId];
+      if (entityConfig.group.action) {
+        let action = entityConfig.group.action;
+        if (action.service) {
+          let domain = action.domain ? action.domain : window.HAWS.extractDomain(entityId);
+          domain = (domain == 'group') ? 'homeassistant' : domain;
+
+          let data = {};
+          if (action.data) {
+            data = action.data;
+          }
+          if (action.data_template) {
+            let entities = this.instance.hass.states;
+            let entityState = entities[entityId];
+
+            let result = this.instance.assemble(action.data_template, entityState, entities);
+            data = JSON.parse(result);
+          }
+
+          if (!data.entity_id) {
+            data['entity_id'] = entityId;
+          }
+
+          this.instance.hass.callService(domain, action.service, data);
+        }
+        else {
+          this.instance.fire('hass-more-info', { entityId: entityId });
+        }
+      }
+      else {
+        this.instance.fire('hass-more-info', { entityId: entityId });
+      }
+    },
+
+    getFill(stateConfig) {
+      let fill = undefined;
+
+      for (let cssRule of this.cssRules) {
+        if (cssRule.selectorText && cssRule.selectorText.indexOf(`.${stateConfig.class}`) >= 0) {
+          if (cssRule.style && cssRule.style.fill) {
+            if (cssRule.style.fill[0] === '#') {
+              fill = cssRule.style.fill;
+            }
+            else {
+              let rgb = cssRule.style.fill.substring(4).slice(0, -1).split(',').map(x => parseInt(x));
+              fill = `#${rgb[0].toString(16)[0]}${rgb[1].toString(16)[0]}${rgb[2].toString(16)[0]}`;
+            }
+          }
+        }
+      }
+
+      return fill;
+    },
+
+    getStroke(stateConfig) {
+      let stroke = undefined;
+
+      for (let cssRule of this.cssRules) {
+        if (cssRule.selectorText && cssRule.selectorText.indexOf(`.${stateConfig.class}`) >= 0) {
+          if (cssRule.style && cssRule.style.stroke) {
+            if (cssRule.style.stroke[0] === '#') {
+              stroke = cssRule.style.stroke;
+            }
+            else {
+              let rgb = cssRule.style.stroke.substring(4).slice(0, -1).split(',').map(x => parseInt(x));
+              stroke = `#${rgb[0].toString(16)[0]}${rgb[1].toString(16)[0]}${rgb[2].toString(16)[0]}`;
+            }
+          }
+        }
+      }
+
+      return stroke;
+    },
+
+    setTransitionFill(svgElement, fromFill, toFill, value) {
+      if (value >= 1) {
+        svgElement.style.fill = fromFill;
+      }
+      else if (value <= 0) {
+        svgElement.style.fill = toFill;
+      }
+      else {
+        let color = this.rgbToHex(this.mix(this.hexToRgb(toFill), this.hexToRgb(fromFill), value));
+        svgElement.style.fill = color;
+      }
+    },
+
+    getServerMoment() {
+      let serverMoment = moment();
+      if (this.timeDifference >= 0)
+        serverMoment.subtract(this.timeDifference, 'milliseconds');
+      else
+        serverMoment.add(Math.abs(this.timeDifference), 'milliseconds');
+      return serverMoment;
+    },
+
+    getArray(list) {
+      return Array.isArray(list) ? list : Object.keys(list).map(key => list[key]);
+    },
+
+    assemble(code, entity, entities) {
+      let functionBody = (code.indexOf('return') >= 0) ? code : `return \`${code}\`;`;
+      let func = new Function('entity', 'entities', 'hass', 'config', functionBody);
+      return func(entity, entities, this.hass, this.config);
+    },
+
+    error(message) {
+      let errors = Polymer.dom(this.$.errors).node;
+      $(errors).find('ul').append(`<li>${message}</li>`)
+      $(errors).css('display', 'block');
+    },
+
+    warn(message) {
+      if ((this.config.warnings === null) || (this.config.warnings !== undefined)) {
+        let warnings = Polymer.dom(this.$.warnings).node;
+        $(warnings).find('ul').append(`<li>${message}</li>`)
+        $(warnings).css('display', 'block');
+      }
+    },
+
+    debug(message) {
+      let debug = Polymer.dom(this.$.debug).node;
+      $(debug).find('ul').append(`<li>${message}</li>`)
+      $(debug).css('display', 'block');
+    },
+
+    loadStyleSheet(path, fn, scope) {
+      let head = document.getElementsByTagName('head')[0]; // reference to document.head for appending/ removing link nodes
+      let link = document.createElement('link');           // create the link node
+      link.setAttribute('href', path);
+      link.setAttribute('rel', 'stylesheet');
+      link.setAttribute('type', 'text/css');
+
+      let sheet, cssRules;
+      // get the correct properties to check for depending on the browser
+      if ('sheet' in link) {
+        sheet = 'sheet'; cssRules = 'cssRules';
+      }
+      else {
+        sheet = 'styleSheet'; cssRules = 'rules';
+      }
+
+      let interval_id = setInterval(function () {                     // start checking whether the style sheet has successfully loaded
+        try {
+          if (link[sheet] && link[sheet][cssRules].length) { // SUCCESS! our style sheet has loaded
+            clearInterval(interval_id);                      // clear the counters
+            clearTimeout(timeout_id);
+            fn.call(scope || window, true, link);           // fire the callback with success == true
+          }
+        } catch (e) { } finally { }
+      }, 10),                                                   // how often to check if the stylesheet is loaded
+        timeout_id = setTimeout(function () {       // start counting down till fail
+          clearInterval(interval_id);             // clear the counters
+          clearTimeout(timeout_id);
+          head.removeChild(link);                // since the style sheet didn't load, remove the link node from the DOM
+          fn.call(scope || window, false, link); // fire the callback with success == false
+        }, 15000);                                 // how long to wait before failing
+
+      head.appendChild(link);  // insert the link node into the DOM and start loading the style sheet
+
+      return link; // return the link node;
+    },
+
+    rgbToHex(rgb) {
+      return "#" + ((1 << 24) + (rgb[0] << 16) + (rgb[1] << 8) + rgb[2]).toString(16).slice(1);
+    },
+
+    hexToRgb(hex) {
+      // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+      let shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+      hex = hex.replace(shorthandRegex, (m, r, g, b) => {
+        return r + r + g + g + b + b;
+      });
+
+      let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+      return result ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16)
+      } : null;
+    },
+
+    mix(color1, color2, weight) {
+      let p = weight;
+      let w = p * 2 - 1;
+      let w1 = ((w / 1) + 1) / 2;
+      let w2 = 1 - w1;
+      let rgb = [
+        Math.round(color1.r * w1 + color2.r * w2),
+        Math.round(color1.g * w1 + color2.g * w2),
+        Math.round(color1.b * w1 + color2.b * w2)
+      ];
+      return rgb;
+    }
+  });
+
+</script>

--- a/www/custom_ui/floorplan/images/weather/cloudy-day-1.svg
+++ b/www/custom_ui/floorplan/images/weather/cloudy-day-1.svg
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="cloudy-day-1">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#C6DEFF" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/cloudy-day-2.svg
+++ b/www/custom_ui/floorplan/images/weather/cloudy-day-2.svg
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="cloudy-day-2">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+    
+</svg>

--- a/www/custom_ui/floorplan/images/weather/cloudy-day-3.svg
+++ b/www/custom_ui/floorplan/images/weather/cloudy-day-3.svg
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="cloudy-day-3">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/cloudy-night-1.svg
+++ b/www/custom_ui/floorplan/images/weather/cloudy-night-1.svg
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** MOON
+*/
+@keyframes am-weather-moon {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  50% {
+    -webkit-transform: rotate(15deg);
+       -moz-transform: rotate(15deg);
+        -ms-transform: rotate(15deg);
+            transform: rotate(15deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+}
+
+.am-weather-moon {
+  -webkit-animation-name: am-weather-moon;
+     -moz-animation-name: am-weather-moon;
+      -ms-animation-name: am-weather-moon;
+          animation-name: am-weather-moon;
+  -webkit-animation-duration: 6s;
+     -moz-animation-duration: 6s;
+      -ms-animation-duration: 6s;
+          animation-duration: 6s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+  -webkit-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+     -moz-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+      -ms-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+          transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+}
+
+@keyframes am-weather-moon-star-1 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-1 {
+  -webkit-animation-name: am-weather-moon-star-1;
+     -moz-animation-name: am-weather-moon-star-1;
+      -ms-animation-name: am-weather-moon-star-1;
+          animation-name: am-weather-moon-star-1;
+  -webkit-animation-delay: 3s;
+     -moz-animation-delay: 3s;
+      -ms-animation-delay: 3s;
+          animation-delay: 3s;
+  -webkit-animation-duration: 5s;
+     -moz-animation-duration: 5s;
+      -ms-animation-duration: 5s;
+          animation-duration: 5s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+@keyframes am-weather-moon-star-2 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-2 {
+  -webkit-animation-name: am-weather-moon-star-2;
+     -moz-animation-name: am-weather-moon-star-2;
+      -ms-animation-name: am-weather-moon-star-2;
+          animation-name: am-weather-moon-star-2;
+  -webkit-animation-delay: 5s;
+     -moz-animation-delay: 5s;
+      -ms-animation-delay: 5s;
+          animation-delay: 5s;
+  -webkit-animation-duration: 4s;
+     -moz-animation-duration: 4s;
+      -ms-animation-duration: 4s;
+          animation-duration: 4s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="cloudy-night-1">
+        <g transform="translate(20,10)">
+            <g transform="translate(16,4), scale(0.8)">
+                <g class="am-weather-moon-star-1">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+                </g>
+                <g class="am-weather-moon-star-2">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+                </g>
+                <g class="am-weather-moon">
+                    <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+                </g>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4    c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#C6DEFF" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/cloudy-night-2.svg
+++ b/www/custom_ui/floorplan/images/weather/cloudy-night-2.svg
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** MOON
+*/
+@keyframes am-weather-moon {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  50% {
+    -webkit-transform: rotate(15deg);
+       -moz-transform: rotate(15deg);
+        -ms-transform: rotate(15deg);
+            transform: rotate(15deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+}
+
+.am-weather-moon {
+  -webkit-animation-name: am-weather-moon;
+     -moz-animation-name: am-weather-moon;
+      -ms-animation-name: am-weather-moon;
+          animation-name: am-weather-moon;
+  -webkit-animation-duration: 6s;
+     -moz-animation-duration: 6s;
+      -ms-animation-duration: 6s;
+          animation-duration: 6s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+  -webkit-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+     -moz-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+      -ms-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+          transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+}
+
+@keyframes am-weather-moon-star-1 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-1 {
+  -webkit-animation-name: am-weather-moon-star-1;
+     -moz-animation-name: am-weather-moon-star-1;
+      -ms-animation-name: am-weather-moon-star-1;
+          animation-name: am-weather-moon-star-1;
+  -webkit-animation-delay: 3s;
+     -moz-animation-delay: 3s;
+      -ms-animation-delay: 3s;
+          animation-delay: 3s;
+  -webkit-animation-duration: 5s;
+     -moz-animation-duration: 5s;
+      -ms-animation-duration: 5s;
+          animation-duration: 5s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+@keyframes am-weather-moon-star-2 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-2 {
+  -webkit-animation-name: am-weather-moon-star-2;
+     -moz-animation-name: am-weather-moon-star-2;
+      -ms-animation-name: am-weather-moon-star-2;
+          animation-name: am-weather-moon-star-2;
+  -webkit-animation-delay: 5s;
+     -moz-animation-delay: 5s;
+      -ms-animation-delay: 5s;
+          animation-delay: 5s;
+  -webkit-animation-duration: 4s;
+     -moz-animation-duration: 4s;
+      -ms-animation-duration: 4s;
+          animation-duration: 4s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="cloudy-night-2">
+        <g transform="translate(20,10)">
+            <g transform="translate(16,4), scale(0.8)">
+                <g class="am-weather-moon-star-1">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+                </g>
+                <g class="am-weather-moon-star-2">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+                </g>
+                <g class="am-weather-moon">
+                    <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+                </g>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4    c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/cloudy-night-3.svg
+++ b/www/custom_ui/floorplan/images/weather/cloudy-night-3.svg
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** MOON
+*/
+@keyframes am-weather-moon {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  50% {
+    -webkit-transform: rotate(15deg);
+       -moz-transform: rotate(15deg);
+        -ms-transform: rotate(15deg);
+            transform: rotate(15deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+}
+
+.am-weather-moon {
+  -webkit-animation-name: am-weather-moon;
+     -moz-animation-name: am-weather-moon;
+      -ms-animation-name: am-weather-moon;
+          animation-name: am-weather-moon;
+  -webkit-animation-duration: 6s;
+     -moz-animation-duration: 6s;
+      -ms-animation-duration: 6s;
+          animation-duration: 6s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+  -webkit-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+     -moz-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+      -ms-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+          transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+}
+
+@keyframes am-weather-moon-star-1 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-1 {
+  -webkit-animation-name: am-weather-moon-star-1;
+     -moz-animation-name: am-weather-moon-star-1;
+      -ms-animation-name: am-weather-moon-star-1;
+          animation-name: am-weather-moon-star-1;
+  -webkit-animation-delay: 3s;
+     -moz-animation-delay: 3s;
+      -ms-animation-delay: 3s;
+          animation-delay: 3s;
+  -webkit-animation-duration: 5s;
+     -moz-animation-duration: 5s;
+      -ms-animation-duration: 5s;
+          animation-duration: 5s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+@keyframes am-weather-moon-star-2 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-2 {
+  -webkit-animation-name: am-weather-moon-star-2;
+     -moz-animation-name: am-weather-moon-star-2;
+      -ms-animation-name: am-weather-moon-star-2;
+          animation-name: am-weather-moon-star-2;
+  -webkit-animation-delay: 5s;
+     -moz-animation-delay: 5s;
+      -ms-animation-delay: 5s;
+          animation-delay: 5s;
+  -webkit-animation-duration: 4s;
+     -moz-animation-duration: 4s;
+      -ms-animation-duration: 4s;
+          animation-duration: 4s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="cloudy-night-3">
+        <g transform="translate(20,10)">
+            <g transform="translate(16,4), scale(0.8)">
+                <g class="am-weather-moon-star-1">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+                </g>
+                <g class="am-weather-moon-star-2">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+                </g>
+                <g class="am-weather-moon">
+                    <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+                </g>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4    c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/cloudy.svg
+++ b/www/custom_ui/floorplan/images/weather/cloudy.svg
@@ -1,0 +1,500 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+        <feMerge> 
+          <feMergeNode/>
+          <feMergeNode in="SourceGraphic"/> 
+        </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-1 {
+  0% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(10px,0px);
+       -moz-transform: translate(10px,0px);
+        -ms-transform: translate(10px,0px);
+            transform: translate(10px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+}
+
+.am-weather-cloud-1 {
+  -webkit-animation-name: am-weather-cloud-1;
+     -moz-animation-name: am-weather-cloud-1;
+          animation-name: am-weather-cloud-1;
+  -webkit-animation-duration: 7s;
+     -moz-animation-duration: 7s;
+          animation-duration: 7s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+
+
+/*
+** MOON
+*/
+@keyframes am-weather-moon {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  50% {
+    -webkit-transform: rotate(15deg);
+       -moz-transform: rotate(15deg);
+        -ms-transform: rotate(15deg);
+            transform: rotate(15deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+}
+
+.am-weather-moon {
+  -webkit-animation-name: am-weather-moon;
+     -moz-animation-name: am-weather-moon;
+      -ms-animation-name: am-weather-moon;
+          animation-name: am-weather-moon;
+  -webkit-animation-duration: 6s;
+     -moz-animation-duration: 6s;
+      -ms-animation-duration: 6s;
+          animation-duration: 6s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+  -webkit-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+     -moz-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+      -ms-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+          transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+}
+
+@keyframes am-weather-moon-star-1 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-1 {
+  -webkit-animation-name: am-weather-moon-star-1;
+     -moz-animation-name: am-weather-moon-star-1;
+      -ms-animation-name: am-weather-moon-star-1;
+          animation-name: am-weather-moon-star-1;
+  -webkit-animation-delay: 3s;
+     -moz-animation-delay: 3s;
+      -ms-animation-delay: 3s;
+          animation-delay: 3s;
+  -webkit-animation-duration: 5s;
+     -moz-animation-duration: 5s;
+      -ms-animation-duration: 5s;
+          animation-duration: 5s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+@keyframes am-weather-moon-star-2 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-2 {
+  -webkit-animation-name: am-weather-moon-star-2;
+     -moz-animation-name: am-weather-moon-star-2;
+      -ms-animation-name: am-weather-moon-star-2;
+          animation-name: am-weather-moon-star-2;
+  -webkit-animation-delay: 5s;
+     -moz-animation-delay: 5s;
+      -ms-animation-delay: 5s;
+          animation-delay: 5s;
+  -webkit-animation-duration: 4s;
+     -moz-animation-duration: 4s;
+      -ms-animation-duration: 4s;
+          animation-duration: 4s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-rain-2 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-delay: 0.25s;
+     -moz-animation-delay: 0.25s;
+      -ms-animation-delay: 0.25s;
+          animation-delay: 0.25s;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(-1.2px) translateY(2px);
+       -moz-transform: translateX(-1.2px) translateY(2px);
+        -ms-transform: translateX(-1.2px) translateY(2px);
+            transform: translateX(-1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(1.4px) translateY(4px);
+       -moz-transform: translateX(1.4px) translateY(4px);
+        -ms-transform: translateX(1.4px) translateY(4px);
+            transform: translateX(1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(-1.6px) translateY(6px);
+       -moz-transform: translateX(-1.6px) translateY(6px);
+        -ms-transform: translateX(-1.6px) translateY(6px);
+            transform: translateX(-1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+@keyframes am-weather-snow-reverse {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(1.2px) translateY(2px);
+       -moz-transform: translateX(1.2px) translateY(2px);
+        -ms-transform: translateX(1.2px) translateY(2px);
+            transform: translateX(1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(-1.4px) translateY(4px);
+       -moz-transform: translateX(-1.4px) translateY(4px);
+        -ms-transform: translateX(-1.4px) translateY(4px);
+            transform: translateX(-1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(1.6px) translateY(6px);
+       -moz-transform: translateX(1.6px) translateY(6px);
+        -ms-transform: translateX(1.6px) translateY(6px);
+            transform: translateX(1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-2 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-delay: 1.2s;
+     -moz-animation-delay: 1.2s;
+      -ms-animation-delay: 1.2s;
+          animation-delay: 1.2s;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-3 {
+  -webkit-animation-name: am-weather-snow-reverse;
+     -moz-animation-name: am-weather-snow-reverse;
+      -ms-animation-name: am-weather-snow-reverse;
+          animation-name: am-weather-snow-reverse;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** EASING
+*/
+.am-weather-easing-ease-in-out {
+  -webkit-animation-timing-function: ease-in-out;
+     -moz-animation-timing-function: ease-in-out;
+      -ms-animation-timing-function: ease-in-out;
+          animation-timing-function: ease-in-out;
+}
+
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="cloudy">
+        <g transform="translate(20,10)">
+            <g class="am-weather-cloud-1">
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-10,-8), scale(0.6)"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/day.svg
+++ b/www/custom_ui/floorplan/images/weather/day.svg
@@ -1,0 +1,521 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-1 {
+  0% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(10px,0px);
+       -moz-transform: translate(10px,0px);
+        -ms-transform: translate(10px,0px);
+            transform: translate(10px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+}
+
+.am-weather-cloud-1 {
+  -webkit-animation-name: am-weather-cloud-1;
+     -moz-animation-name: am-weather-cloud-1;
+          animation-name: am-weather-cloud-1;
+  -webkit-animation-duration: 7s;
+     -moz-animation-duration: 7s;
+          animation-duration: 7s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+
+
+/*
+** MOON
+*/
+@keyframes am-weather-moon {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  50% {
+    -webkit-transform: rotate(15deg);
+       -moz-transform: rotate(15deg);
+        -ms-transform: rotate(15deg);
+            transform: rotate(15deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+}
+
+.am-weather-moon {
+  -webkit-animation-name: am-weather-moon;
+     -moz-animation-name: am-weather-moon;
+      -ms-animation-name: am-weather-moon;
+          animation-name: am-weather-moon;
+  -webkit-animation-duration: 6s;
+     -moz-animation-duration: 6s;
+      -ms-animation-duration: 6s;
+          animation-duration: 6s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+  -webkit-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+     -moz-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+      -ms-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+          transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+}
+
+@keyframes am-weather-moon-star-1 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-1 {
+  -webkit-animation-name: am-weather-moon-star-1;
+     -moz-animation-name: am-weather-moon-star-1;
+      -ms-animation-name: am-weather-moon-star-1;
+          animation-name: am-weather-moon-star-1;
+  -webkit-animation-delay: 3s;
+     -moz-animation-delay: 3s;
+      -ms-animation-delay: 3s;
+          animation-delay: 3s;
+  -webkit-animation-duration: 5s;
+     -moz-animation-duration: 5s;
+      -ms-animation-duration: 5s;
+          animation-duration: 5s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+@keyframes am-weather-moon-star-2 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-2 {
+  -webkit-animation-name: am-weather-moon-star-2;
+     -moz-animation-name: am-weather-moon-star-2;
+      -ms-animation-name: am-weather-moon-star-2;
+          animation-name: am-weather-moon-star-2;
+  -webkit-animation-delay: 5s;
+     -moz-animation-delay: 5s;
+      -ms-animation-delay: 5s;
+          animation-delay: 5s;
+  -webkit-animation-duration: 4s;
+     -moz-animation-duration: 4s;
+      -ms-animation-duration: 4s;
+          animation-duration: 4s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-rain-2 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-delay: 0.25s;
+     -moz-animation-delay: 0.25s;
+      -ms-animation-delay: 0.25s;
+          animation-delay: 0.25s;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(-1.2px) translateY(2px);
+       -moz-transform: translateX(-1.2px) translateY(2px);
+        -ms-transform: translateX(-1.2px) translateY(2px);
+            transform: translateX(-1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(1.4px) translateY(4px);
+       -moz-transform: translateX(1.4px) translateY(4px);
+        -ms-transform: translateX(1.4px) translateY(4px);
+            transform: translateX(1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(-1.6px) translateY(6px);
+       -moz-transform: translateX(-1.6px) translateY(6px);
+        -ms-transform: translateX(-1.6px) translateY(6px);
+            transform: translateX(-1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+@keyframes am-weather-snow-reverse {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(1.2px) translateY(2px);
+       -moz-transform: translateX(1.2px) translateY(2px);
+        -ms-transform: translateX(1.2px) translateY(2px);
+            transform: translateX(1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(-1.4px) translateY(4px);
+       -moz-transform: translateX(-1.4px) translateY(4px);
+        -ms-transform: translateX(-1.4px) translateY(4px);
+            transform: translateX(-1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(1.6px) translateY(6px);
+       -moz-transform: translateX(1.6px) translateY(6px);
+        -ms-transform: translateX(1.6px) translateY(6px);
+            transform: translateX(1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-2 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-delay: 1.2s;
+     -moz-animation-delay: 1.2s;
+      -ms-animation-delay: 1.2s;
+          animation-delay: 1.2s;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-3 {
+  -webkit-animation-name: am-weather-snow-reverse;
+     -moz-animation-name: am-weather-snow-reverse;
+      -ms-animation-name: am-weather-snow-reverse;
+          animation-name: am-weather-snow-reverse;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** EASING
+*/
+.am-weather-easing-ease-in-out {
+  -webkit-animation-timing-function: ease-in-out;
+     -moz-animation-timing-function: ease-in-out;
+      -ms-animation-timing-function: ease-in-out;
+          animation-timing-function: ease-in-out;
+}
+
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="day">
+        <g transform="translate(32,32)">
+            <g class="am-weather-sun am-weather-sun-shiny am-weather-easing-ease-in-out">
+                <g>
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(45)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(90)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(135)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(180)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(225)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(270)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(315)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+            </g>
+            <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/night.svg
+++ b/www/custom_ui/floorplan/images/weather/night.svg
@@ -1,0 +1,503 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-1 {
+  0% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(10px,0px);
+       -moz-transform: translate(10px,0px);
+        -ms-transform: translate(10px,0px);
+            transform: translate(10px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+}
+
+.am-weather-cloud-1 {
+  -webkit-animation-name: am-weather-cloud-1;
+     -moz-animation-name: am-weather-cloud-1;
+          animation-name: am-weather-cloud-1;
+  -webkit-animation-duration: 7s;
+     -moz-animation-duration: 7s;
+          animation-duration: 7s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+
+
+/*
+** MOON
+*/
+@keyframes am-weather-moon {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  50% {
+    -webkit-transform: rotate(15deg);
+       -moz-transform: rotate(15deg);
+        -ms-transform: rotate(15deg);
+            transform: rotate(15deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+}
+
+.am-weather-moon {
+  -webkit-animation-name: am-weather-moon;
+     -moz-animation-name: am-weather-moon;
+      -ms-animation-name: am-weather-moon;
+          animation-name: am-weather-moon;
+  -webkit-animation-duration: 6s;
+     -moz-animation-duration: 6s;
+      -ms-animation-duration: 6s;
+          animation-duration: 6s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+  -webkit-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+     -moz-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+      -ms-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+          transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+}
+
+@keyframes am-weather-moon-star-1 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-1 {
+  -webkit-animation-name: am-weather-moon-star-1;
+     -moz-animation-name: am-weather-moon-star-1;
+      -ms-animation-name: am-weather-moon-star-1;
+          animation-name: am-weather-moon-star-1;
+  -webkit-animation-delay: 3s;
+     -moz-animation-delay: 3s;
+      -ms-animation-delay: 3s;
+          animation-delay: 3s;
+  -webkit-animation-duration: 5s;
+     -moz-animation-duration: 5s;
+      -ms-animation-duration: 5s;
+          animation-duration: 5s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+@keyframes am-weather-moon-star-2 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-2 {
+  -webkit-animation-name: am-weather-moon-star-2;
+     -moz-animation-name: am-weather-moon-star-2;
+      -ms-animation-name: am-weather-moon-star-2;
+          animation-name: am-weather-moon-star-2;
+  -webkit-animation-delay: 5s;
+     -moz-animation-delay: 5s;
+      -ms-animation-delay: 5s;
+          animation-delay: 5s;
+  -webkit-animation-duration: 4s;
+     -moz-animation-duration: 4s;
+      -ms-animation-duration: 4s;
+          animation-duration: 4s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-rain-2 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-delay: 0.25s;
+     -moz-animation-delay: 0.25s;
+      -ms-animation-delay: 0.25s;
+          animation-delay: 0.25s;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(-1.2px) translateY(2px);
+       -moz-transform: translateX(-1.2px) translateY(2px);
+        -ms-transform: translateX(-1.2px) translateY(2px);
+            transform: translateX(-1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(1.4px) translateY(4px);
+       -moz-transform: translateX(1.4px) translateY(4px);
+        -ms-transform: translateX(1.4px) translateY(4px);
+            transform: translateX(1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(-1.6px) translateY(6px);
+       -moz-transform: translateX(-1.6px) translateY(6px);
+        -ms-transform: translateX(-1.6px) translateY(6px);
+            transform: translateX(-1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+@keyframes am-weather-snow-reverse {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(1.2px) translateY(2px);
+       -moz-transform: translateX(1.2px) translateY(2px);
+        -ms-transform: translateX(1.2px) translateY(2px);
+            transform: translateX(1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(-1.4px) translateY(4px);
+       -moz-transform: translateX(-1.4px) translateY(4px);
+        -ms-transform: translateX(-1.4px) translateY(4px);
+            transform: translateX(-1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(1.6px) translateY(6px);
+       -moz-transform: translateX(1.6px) translateY(6px);
+        -ms-transform: translateX(1.6px) translateY(6px);
+            transform: translateX(1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-2 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-delay: 1.2s;
+     -moz-animation-delay: 1.2s;
+      -ms-animation-delay: 1.2s;
+          animation-delay: 1.2s;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-3 {
+  -webkit-animation-name: am-weather-snow-reverse;
+     -moz-animation-name: am-weather-snow-reverse;
+      -ms-animation-name: am-weather-snow-reverse;
+          animation-name: am-weather-snow-reverse;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** EASING
+*/
+.am-weather-easing-ease-in-out {
+  -webkit-animation-timing-function: ease-in-out;
+     -moz-animation-timing-function: ease-in-out;
+      -ms-animation-timing-function: ease-in-out;
+          animation-timing-function: ease-in-out;
+}
+
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="night">
+        <g transform="translate(20,20)">
+            <g class="am-weather-moon-star-1">
+                <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+            </g>
+            <g class="am-weather-moon-star-2">
+                <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+            </g>
+            <g class="am-weather-moon">
+                <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/rainy-1.svg
+++ b/www/custom_ui/floorplan/images/weather/rainy-1.svg
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-rain-2 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-delay: 0.25s;
+     -moz-animation-delay: 0.25s;
+      -ms-animation-delay: 0.25s;
+          animation-delay: 0.25s;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="rainy-1">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16), scale(1.2)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.5" transform="translate(-15,-5), scale(0.85)"/>
+            </g>
+        </g>
+        <g transform="translate(34,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/rainy-2.svg
+++ b/www/custom_ui/floorplan/images/weather/rainy-2.svg
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="rainy-2">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(37,45), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/rainy-3.svg
+++ b/www/custom_ui/floorplan/images/weather/rainy-3.svg
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-rain-2 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-delay: 0.25s;
+     -moz-animation-delay: 0.25s;
+      -ms-animation-delay: 0.25s;
+          animation-delay: 0.25s;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="rainy-3">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fifll="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(34,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/rainy-4.svg
+++ b/www/custom_ui/floorplan/images/weather/rainy-4.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="rainy-4">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(37,45), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/rainy-5.svg
+++ b/www/custom_ui/floorplan/images/weather/rainy-5.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-rain-2 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-delay: 0.25s;
+     -moz-animation-delay: 0.25s;
+      -ms-animation-delay: 0.25s;
+          animation-delay: 0.25s;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="rainy-5">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(34,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/rainy-6.svg
+++ b/www/custom_ui/floorplan/images/weather/rainy-6.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-rain-2 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-delay: 0.25s;
+     -moz-animation-delay: 0.25s;
+      -ms-animation-delay: 0.25s;
+          animation-delay: 0.25s;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="rainy-6">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(31,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,4" stroke-linecap="round" stroke-width="2" transform="translate(-4,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,4" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,4" stroke-linecap="round" stroke-width="2" transform="translate(4,0)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/rainy-7.svg
+++ b/www/custom_ui/floorplan/images/weather/rainy-7.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-rain-2 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-delay: 0.25s;
+     -moz-animation-delay: 0.25s;
+      -ms-animation-delay: 0.25s;
+          animation-delay: 0.25s;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="rainy-7">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(31,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="0.1,7" stroke-linecap="round" stroke-width="3" transform="translate(-5,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="0.1,7" stroke-linecap="round" stroke-width="3" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="0.1,7" stroke-linecap="round" stroke-width="3" transform="translate(5,0)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/snowy-1.svg
+++ b/www/custom_ui/floorplan/images/weather/snowy-1.svg
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(-1.2px) translateY(2px);
+       -moz-transform: translateX(-1.2px) translateY(2px);
+        -ms-transform: translateX(-1.2px) translateY(2px);
+            transform: translateX(-1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(1.4px) translateY(4px);
+       -moz-transform: translateX(1.4px) translateY(4px);
+        -ms-transform: translateX(1.4px) translateY(4px);
+            transform: translateX(1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(-1.6px) translateY(6px);
+       -moz-transform: translateX(-1.6px) translateY(6px);
+        -ms-transform: translateX(-1.6px) translateY(6px);
+            transform: translateX(-1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-2 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-delay: 1.2s;
+     -moz-animation-delay: 1.2s;
+      -ms-animation-delay: 1.2s;
+          animation-delay: 1.2s;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="snowy-1">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16), scale(1.2)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.5" transform="translate(-15,-5), scale(0.85)"/>
+            </g>
+        </g>
+        <g transform="translate(20,9)">
+            <g class="am-weather-snow-1">
+                <g transform="translate(7,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(16,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/snowy-2.svg
+++ b/www/custom_ui/floorplan/images/weather/snowy-2.svg
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(-1.2px) translateY(2px);
+       -moz-transform: translateX(-1.2px) translateY(2px);
+        -ms-transform: translateX(-1.2px) translateY(2px);
+            transform: translateX(-1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(1.4px) translateY(4px);
+       -moz-transform: translateX(1.4px) translateY(4px);
+        -ms-transform: translateX(1.4px) translateY(4px);
+            transform: translateX(1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(-1.6px) translateY(6px);
+       -moz-transform: translateX(-1.6px) translateY(6px);
+        -ms-transform: translateX(-1.6px) translateY(6px);
+            transform: translateX(-1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="snowy-2">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g class="am-weather-snow-1">
+            <g transform="translate(32,38)">
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/snowy-3.svg
+++ b/www/custom_ui/floorplan/images/weather/snowy-3.svg
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(-1.2px) translateY(2px);
+       -moz-transform: translateX(-1.2px) translateY(2px);
+        -ms-transform: translateX(-1.2px) translateY(2px);
+            transform: translateX(-1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(1.4px) translateY(4px);
+       -moz-transform: translateX(1.4px) translateY(4px);
+        -ms-transform: translateX(1.4px) translateY(4px);
+            transform: translateX(1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(-1.6px) translateY(6px);
+       -moz-transform: translateX(-1.6px) translateY(6px);
+        -ms-transform: translateX(-1.6px) translateY(6px);
+            transform: translateX(-1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-2 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-delay: 1.2s;
+     -moz-animation-delay: 1.2s;
+      -ms-animation-delay: 1.2s;
+          animation-delay: 1.2s;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="snowy-3">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(7,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(16,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/snowy-4.svg
+++ b/www/custom_ui/floorplan/images/weather/snowy-4.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translate(0.0px,0);
+       -moz-transform: translate(0.0px,0);
+        -ms-transform: translate(0.0px,0);
+            transform: translate(0.0px,0);
+  }
+
+  33.33% {
+    -webkit-transform: translate(-1.2px,2px);
+       -moz-transform: translate(-1.2px,2px);
+        -ms-transform: translate(-1.2px,2px);
+            transform: translate(-1.2px,2px);
+  }
+
+  66.66% {
+    -webkit-transform: translate(1.4px,4px);
+       -moz-transform: translate(1.4px,4px);
+        -ms-transform: translate(1.4px,4px);
+            transform: translate(1.4px,4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translate(-1.6px,6px);
+       -moz-transform: translate(-1.6px,6px);
+        -ms-transform: translate(-1.6px,6px);
+            transform: translate(-1.6px,6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="snowy-4">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(11,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/snowy-5.svg
+++ b/www/custom_ui/floorplan/images/weather/snowy-5.svg
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(-1.2px) translateY(2px);
+       -moz-transform: translateX(-1.2px) translateY(2px);
+        -ms-transform: translateX(-1.2px) translateY(2px);
+            transform: translateX(-1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(1.4px) translateY(4px);
+       -moz-transform: translateX(1.4px) translateY(4px);
+        -ms-transform: translateX(1.4px) translateY(4px);
+            transform: translateX(1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(-1.6px) translateY(6px);
+       -moz-transform: translateX(-1.6px) translateY(6px);
+        -ms-transform: translateX(-1.6px) translateY(6px);
+            transform: translateX(-1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-2 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-delay: 1.2s;
+     -moz-animation-delay: 1.2s;
+      -ms-animation-delay: 1.2s;
+          animation-delay: 1.2s;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="snowy-5">
+        <g transform="translate(20,10)">
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(7,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(16,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/snowy-6.svg
+++ b/www/custom_ui/floorplan/images/weather/snowy-6.svg
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(-1.2px) translateY(2px);
+       -moz-transform: translateX(-1.2px) translateY(2px);
+        -ms-transform: translateX(-1.2px) translateY(2px);
+            transform: translateX(-1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(1.4px) translateY(4px);
+       -moz-transform: translateX(1.4px) translateY(4px);
+        -ms-transform: translateX(1.4px) translateY(4px);
+            transform: translateX(1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(-1.6px) translateY(6px);
+       -moz-transform: translateX(-1.6px) translateY(6px);
+        -ms-transform: translateX(-1.6px) translateY(6px);
+            transform: translateX(-1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+@keyframes am-weather-snow-reverse {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(1.2px) translateY(2px);
+       -moz-transform: translateX(1.2px) translateY(2px);
+        -ms-transform: translateX(1.2px) translateY(2px);
+            transform: translateX(1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(-1.4px) translateY(4px);
+       -moz-transform: translateX(-1.4px) translateY(4px);
+        -ms-transform: translateX(-1.4px) translateY(4px);
+            transform: translateX(-1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(1.6px) translateY(6px);
+       -moz-transform: translateX(1.6px) translateY(6px);
+        -ms-transform: translateX(1.6px) translateY(6px);
+            transform: translateX(1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-2 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-delay: 1.2s;
+     -moz-animation-delay: 1.2s;
+      -ms-animation-delay: 1.2s;
+          animation-delay: 1.2s;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-3 {
+  -webkit-animation-name: am-weather-snow-reverse;
+     -moz-animation-name: am-weather-snow-reverse;
+      -ms-animation-name: am-weather-snow-reverse;
+          animation-name: am-weather-snow-reverse;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="snowy-6">
+        <g transform="translate(20,10)">
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(3,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(11,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-3">
+                <g transform="translate(20,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/thunder.svg
+++ b/www/custom_ui/floorplan/images/weather/thunder.svg
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <filter id="blur" width="200%" height="200%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+            <feOffset dx="0" dy="4" result="offsetblur"/>
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.05"/>
+            </feComponentTransfer>
+            <feMerge> 
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/> 
+            </feMerge>
+        </filter>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-1 {
+  0% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(10px,0px);
+       -moz-transform: translate(10px,0px);
+        -ms-transform: translate(10px,0px);
+            transform: translate(10px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+}
+
+.am-weather-cloud-1 {
+  -webkit-animation-name: am-weather-cloud-1;
+     -moz-animation-name: am-weather-cloud-1;
+          animation-name: am-weather-cloud-1;
+  -webkit-animation-duration: 7s;
+     -moz-animation-duration: 7s;
+          animation-duration: 7s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** STROKE
+*/
+@keyframes am-weather-stroke {
+  0% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  2% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  4% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  6% {
+    -webkit-transform: translate(0.5px,0.4px);
+       -moz-transform: translate(0.5px,0.4px);
+        -ms-transform: translate(0.5px,0.4px);
+            transform: translate(0.5px,0.4px);
+  }
+
+  8% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  10% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  12% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  14% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  16% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  18% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  20% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  22% {
+    -webkit-transform: translate(1px,0.0px);
+       -moz-transform: translate(1px,0.0px);
+        -ms-transform: translate(1px,0.0px);
+            transform: translate(1px,0.0px);
+  }
+
+  24% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  26% {
+    -webkit-transform: translate(-1px,0.0px);
+       -moz-transform: translate(-1px,0.0px);
+        -ms-transform: translate(-1px,0.0px);
+            transform: translate(-1px,0.0px);
+
+  }
+
+  28% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  40% {
+    fill: orange;
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  65% {
+    fill: white;
+    -webkit-transform: translate(-1px,5.0px);
+       -moz-transform: translate(-1px,5.0px);
+        -ms-transform: translate(-1px,5.0px);
+            transform: translate(-1px,5.0px);
+  }
+  61% {
+    fill: orange;
+  }
+
+  100% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+}
+
+.am-weather-stroke {
+  -webkit-animation-name: am-weather-stroke;
+     -moz-animation-name: am-weather-stroke;
+          animation-name: am-weather-stroke;
+  -webkit-animation-duration: 1.11s;
+     -moz-animation-duration: 1.11s;
+          animation-duration: 1.11s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+        ]]></style>
+    </defs>
+    <g filter="url(#blur)" id="thunder">
+        <g transform="translate(20,10)">
+            <g class="am-weather-cloud-1">
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-10,-6), scale(0.6)" />
+            </g>
+            <g>
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)" />
+            </g>
+            <g transform="translate(-9,28), scale(1.2)">
+                <polygon class="am-weather-stroke" fill="orange" stroke="white" stroke-width="1" points="14.3,-2.9 20.5,-2.9 16.4,4.3 20.3,4.3 11.5,14.6 14.9,6.9 11.1,6.9" />
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/weather-sprite.svg
+++ b/www/custom_ui/floorplan/images/weather/weather-sprite.svg
@@ -1,0 +1,1245 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    style="position: absolute; width: 0; height: 0;"
+    width="0"
+    height="0">
+    <defs>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-1 {
+  0% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(10px,0px);
+       -moz-transform: translate(10px,0px);
+        -ms-transform: translate(10px,0px);
+            transform: translate(10px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+}
+
+.am-weather-cloud-1 {
+  -webkit-animation-name: am-weather-cloud-1;
+     -moz-animation-name: am-weather-cloud-1;
+          animation-name: am-weather-cloud-1;
+  -webkit-animation-duration: 7s;
+     -moz-animation-duration: 7s;
+          animation-duration: 7s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** STROKE
+*/
+@keyframes am-weather-stroke {
+  0% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  2% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  4% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  6% {
+    -webkit-transform: translate(0.5px,0.4px);
+       -moz-transform: translate(0.5px,0.4px);
+        -ms-transform: translate(0.5px,0.4px);
+            transform: translate(0.5px,0.4px);
+  }
+
+  8% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  10% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  12% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  14% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  16% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  18% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  20% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  22% {
+    -webkit-transform: translate(1px,0.0px);
+       -moz-transform: translate(1px,0.0px);
+        -ms-transform: translate(1px,0.0px);
+            transform: translate(1px,0.0px);
+  }
+
+  24% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  26% {
+    -webkit-transform: translate(-1px,0.0px);
+       -moz-transform: translate(-1px,0.0px);
+        -ms-transform: translate(-1px,0.0px);
+            transform: translate(-1px,0.0px);
+
+  }
+
+  28% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  40% {
+    fill: orange;
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  65% {
+    fill: white;
+    -webkit-transform: translate(-1px,5.0px);
+       -moz-transform: translate(-1px,5.0px);
+        -ms-transform: translate(-1px,5.0px);
+            transform: translate(-1px,5.0px);
+  }
+  61% {
+    fill: orange;
+  }
+
+  100% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+}
+
+.am-weather-stroke {
+  -webkit-animation-name: am-weather-stroke;
+     -moz-animation-name: am-weather-stroke;
+          animation-name: am-weather-stroke;
+  -webkit-animation-duration: 1.11s;
+     -moz-animation-duration: 1.11s;
+          animation-duration: 1.11s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+
+
+/*
+** MOON
+*/
+@keyframes am-weather-moon {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  50% {
+    -webkit-transform: rotate(15deg);
+       -moz-transform: rotate(15deg);
+        -ms-transform: rotate(15deg);
+            transform: rotate(15deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+}
+
+.am-weather-moon {
+  -webkit-animation-name: am-weather-moon;
+     -moz-animation-name: am-weather-moon;
+      -ms-animation-name: am-weather-moon;
+          animation-name: am-weather-moon;
+  -webkit-animation-duration: 6s;
+     -moz-animation-duration: 6s;
+      -ms-animation-duration: 6s;
+          animation-duration: 6s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+  -webkit-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+     -moz-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+      -ms-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+          transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+}
+
+@keyframes am-weather-moon-star-1 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-1 {
+  -webkit-animation-name: am-weather-moon-star-1;
+     -moz-animation-name: am-weather-moon-star-1;
+      -ms-animation-name: am-weather-moon-star-1;
+          animation-name: am-weather-moon-star-1;
+  -webkit-animation-delay: 3s;
+     -moz-animation-delay: 3s;
+      -ms-animation-delay: 3s;
+          animation-delay: 3s;
+  -webkit-animation-duration: 5s;
+     -moz-animation-duration: 5s;
+      -ms-animation-duration: 5s;
+          animation-duration: 5s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+@keyframes am-weather-moon-star-2 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-2 {
+  -webkit-animation-name: am-weather-moon-star-2;
+     -moz-animation-name: am-weather-moon-star-2;
+      -ms-animation-name: am-weather-moon-star-2;
+          animation-name: am-weather-moon-star-2;
+  -webkit-animation-delay: 5s;
+     -moz-animation-delay: 5s;
+      -ms-animation-delay: 5s;
+          animation-delay: 5s;
+  -webkit-animation-duration: 4s;
+     -moz-animation-duration: 4s;
+      -ms-animation-duration: 4s;
+          animation-duration: 4s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-rain-2 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-delay: 0.25s;
+     -moz-animation-delay: 0.25s;
+      -ms-animation-delay: 0.25s;
+          animation-delay: 0.25s;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(-1.2px) translateY(2px);
+       -moz-transform: translateX(-1.2px) translateY(2px);
+        -ms-transform: translateX(-1.2px) translateY(2px);
+            transform: translateX(-1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(1.4px) translateY(4px);
+       -moz-transform: translateX(1.4px) translateY(4px);
+        -ms-transform: translateX(1.4px) translateY(4px);
+            transform: translateX(1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(-1.6px) translateY(6px);
+       -moz-transform: translateX(-1.6px) translateY(6px);
+        -ms-transform: translateX(-1.6px) translateY(6px);
+            transform: translateX(-1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+@keyframes am-weather-snow-reverse {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(1.2px) translateY(2px);
+       -moz-transform: translateX(1.2px) translateY(2px);
+        -ms-transform: translateX(1.2px) translateY(2px);
+            transform: translateX(1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(-1.4px) translateY(4px);
+       -moz-transform: translateX(-1.4px) translateY(4px);
+        -ms-transform: translateX(-1.4px) translateY(4px);
+            transform: translateX(-1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(1.6px) translateY(6px);
+       -moz-transform: translateX(1.6px) translateY(6px);
+        -ms-transform: translateX(1.6px) translateY(6px);
+            transform: translateX(1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-2 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-delay: 1.2s;
+     -moz-animation-delay: 1.2s;
+      -ms-animation-delay: 1.2s;
+          animation-delay: 1.2s;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-3 {
+  -webkit-animation-name: am-weather-snow-reverse;
+     -moz-animation-name: am-weather-snow-reverse;
+      -ms-animation-name: am-weather-snow-reverse;
+          animation-name: am-weather-snow-reverse;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** EASING
+*/
+.am-weather-easing-ease-in-out {
+  -webkit-animation-timing-function: ease-in-out;
+     -moz-animation-timing-function: ease-in-out;
+      -ms-animation-timing-function: ease-in-out;
+          animation-timing-function: ease-in-out;
+}
+
+        ]]></style>
+    </defs>
+    <symbol id="thunder" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g class="am-weather-cloud-1">
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-10,-6), scale(0.6)" />
+            </g>
+            <g>
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)" />
+            </g>
+            <g transform="translate(-9,28), scale(1.2)">
+                <polygon class="am-weather-stroke" fill="orange" stroke="white" stroke-width="1" points="14.3,-2.9 20.5,-2.9 16.4,4.3 20.3,4.3 11.5,14.6 14.9,6.9 11.1,6.9" />
+            </g>
+        </g>
+    </symbol>
+    <symbol id="day" viewBox="0 0 64 64">
+        <g transform="translate(32,32)">
+            <g class="am-weather-sun am-weather-sun-shiny am-weather-easing-ease-in-out">
+                <g>
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(45)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(90)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(135)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(180)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(225)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(270)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(315)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+            </g>
+            <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+        </g>
+    </symbol>
+    <symbol id="night" viewBox="0 0 64 64">
+        <g transform="translate(20,20)">
+            <g class="am-weather-moon-star-1">
+                <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+            </g>
+            <g class="am-weather-moon-star-2">
+                <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+            </g>
+            <g class="am-weather-moon">
+                <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="cloudy-day-1" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#C6DEFF" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="cloudy-night-1" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(16,4), scale(0.8)">
+                <g class="am-weather-moon-star-1">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+                </g>
+                <g class="am-weather-moon-star-2">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+                </g>
+                <g class="am-weather-moon">
+                    <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+                </g>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4    c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#C6DEFF" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="cloudy-day-2" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="cloudy-night-2" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(16,4), scale(0.8)">
+                <g class="am-weather-moon-star-1">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+                </g>
+                <g class="am-weather-moon-star-2">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+                </g>
+                <g class="am-weather-moon">
+                    <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+                </g>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4    c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="cloudy-day-3" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="cloudy-night-3" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(16,4), scale(0.8)">
+                <g class="am-weather-moon-star-1">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+                </g>
+                <g class="am-weather-moon-star-2">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+                </g>
+                <g class="am-weather-moon">
+                    <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+                </g>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4    c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="cloudy" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g class="am-weather-cloud-1">
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-10,-8), scale(0.6)"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="rainy-1" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16), scale(1.2)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.5" transform="translate(-15,-5), scale(0.85)"/>
+            </g>
+        </g>
+        <g transform="translate(34,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </symbol>
+    <symbol id="rainy-2" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(37,45), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </symbol>
+    <symbol id="rainy-3" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fifll="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(34,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </symbol>
+    <symbol id="rainy-4" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(37,45), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </symbol>
+    <symbol id="rainy-5" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(34,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </symbol>
+    <symbol id="rainy-6" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(31,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,4" stroke-linecap="round" stroke-width="2" transform="translate(-4,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,4" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,4" stroke-linecap="round" stroke-width="2" transform="translate(4,0)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </symbol>
+    <symbol id="rainy-7" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(31,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="0.1,7" stroke-linecap="round" stroke-width="3" transform="translate(-5,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="0.1,7" stroke-linecap="round" stroke-width="3" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="0.1,7" stroke-linecap="round" stroke-width="3" transform="translate(5,0)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </symbol>
+    <symbol id="snowy-1" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16), scale(1.2)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.5" transform="translate(-15,-5), scale(0.85)"/>
+            </g>
+        </g>
+        <g transform="translate(20,9)">
+            <g class="am-weather-snow-1">
+                <g transform="translate(7,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(16,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="snowy-2" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g class="am-weather-snow-1">
+            <g transform="translate(32,38)">
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+            </g>
+        </g>
+    </symbol>
+    <symbol id="snowy-3" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(7,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(16,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="snowy-4" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(11,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="snowy-5" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g class="snowy-6-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(7,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(16,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </symbol>
+    <symbol id="snowy-6" viewBox="0 0 64 64">
+        <g transform="translate(20,10)">
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(3,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(11,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-3">
+                <g transform="translate(20,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </symbol>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/weather.svg
+++ b/www/custom_ui/floorplan/images/weather/weather.svg
@@ -1,0 +1,1245 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- (c) ammap.com | SVG weather icons -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="256"
+    height="256"
+    viewBox="0 0 64 64" >
+    <defs>
+        <style type="text/css"><![CDATA[
+/*
+** CLOUDS
+*/
+@keyframes am-weather-cloud-1 {
+  0% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(10px,0px);
+       -moz-transform: translate(10px,0px);
+        -ms-transform: translate(10px,0px);
+            transform: translate(10px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(-5px,0px);
+       -moz-transform: translate(-5px,0px);
+        -ms-transform: translate(-5px,0px);
+            transform: translate(-5px,0px);
+  }
+}
+
+.am-weather-cloud-1 {
+  -webkit-animation-name: am-weather-cloud-1;
+     -moz-animation-name: am-weather-cloud-1;
+          animation-name: am-weather-cloud-1;
+  -webkit-animation-duration: 7s;
+     -moz-animation-duration: 7s;
+          animation-duration: 7s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-cloud-2 {
+  0% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+
+  50% {
+    -webkit-transform: translate(2px,0px);
+       -moz-transform: translate(2px,0px);
+        -ms-transform: translate(2px,0px);
+            transform: translate(2px,0px);
+  }
+
+  100% {
+    -webkit-transform: translate(0px,0px);
+       -moz-transform: translate(0px,0px);
+        -ms-transform: translate(0px,0px);
+            transform: translate(0px,0px);
+  }
+}
+
+.am-weather-cloud-2 {
+  -webkit-animation-name: am-weather-cloud-2;
+     -moz-animation-name: am-weather-cloud-2;
+          animation-name: am-weather-cloud-2;
+  -webkit-animation-duration: 3s;
+     -moz-animation-duration: 3s;
+          animation-duration: 3s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** STROKE
+*/
+@keyframes am-weather-stroke {
+  0% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  2% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  4% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  6% {
+    -webkit-transform: translate(0.5px,0.4px);
+       -moz-transform: translate(0.5px,0.4px);
+        -ms-transform: translate(0.5px,0.4px);
+            transform: translate(0.5px,0.4px);
+  }
+
+  8% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  10% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  12% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  14% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  16% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  18% {
+    -webkit-transform: translate(0.3px,0.0px);
+       -moz-transform: translate(0.3px,0.0px);
+        -ms-transform: translate(0.3px,0.0px);
+            transform: translate(0.3px,0.0px);
+  }
+
+  20% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  22% {
+    -webkit-transform: translate(1px,0.0px);
+       -moz-transform: translate(1px,0.0px);
+        -ms-transform: translate(1px,0.0px);
+            transform: translate(1px,0.0px);
+  }
+
+  24% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  26% {
+    -webkit-transform: translate(-1px,0.0px);
+       -moz-transform: translate(-1px,0.0px);
+        -ms-transform: translate(-1px,0.0px);
+            transform: translate(-1px,0.0px);
+
+  }
+
+  28% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  40% {
+    fill: orange;
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+
+  65% {
+    fill: white;
+    -webkit-transform: translate(-1px,5.0px);
+       -moz-transform: translate(-1px,5.0px);
+        -ms-transform: translate(-1px,5.0px);
+            transform: translate(-1px,5.0px);
+  }
+  61% {
+    fill: orange;
+  }
+
+  100% {
+    -webkit-transform: translate(0.0px,0.0px);
+       -moz-transform: translate(0.0px,0.0px);
+        -ms-transform: translate(0.0px,0.0px);
+            transform: translate(0.0px,0.0px);
+  }
+}
+
+.am-weather-stroke {
+  -webkit-animation-name: am-weather-stroke;
+     -moz-animation-name: am-weather-stroke;
+          animation-name: am-weather-stroke;
+  -webkit-animation-duration: 1.11s;
+     -moz-animation-duration: 1.11s;
+          animation-duration: 1.11s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+
+/*
+** SUN
+*/
+@keyframes am-weather-sun {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+       -moz-transform: rotate(360deg);
+        -ms-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+
+.am-weather-sun {
+  -webkit-animation-name: am-weather-sun;
+     -moz-animation-name: am-weather-sun;
+      -ms-animation-name: am-weather-sun;
+          animation-name: am-weather-sun;
+  -webkit-animation-duration: 9s;
+     -moz-animation-duration: 9s;
+      -ms-animation-duration: 9s;
+          animation-duration: 9s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+@keyframes am-weather-sun-shiny {
+  0% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+
+  50% {
+    stroke-dasharray: 0.1px 10px;
+    stroke-dashoffset: -1px;
+  }
+
+  100% {
+    stroke-dasharray: 3px 10px;
+    stroke-dashoffset: 0px;
+  }
+}
+
+.am-weather-sun-shiny line {
+  -webkit-animation-name: am-weather-sun-shiny;
+     -moz-animation-name: am-weather-sun-shiny;
+      -ms-animation-name: am-weather-sun-shiny;
+          animation-name: am-weather-sun-shiny;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+
+
+/*
+** MOON
+*/
+@keyframes am-weather-moon {
+  0% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+
+  50% {
+    -webkit-transform: rotate(15deg);
+       -moz-transform: rotate(15deg);
+        -ms-transform: rotate(15deg);
+            transform: rotate(15deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(0deg);
+       -moz-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+}
+
+.am-weather-moon {
+  -webkit-animation-name: am-weather-moon;
+     -moz-animation-name: am-weather-moon;
+      -ms-animation-name: am-weather-moon;
+          animation-name: am-weather-moon;
+  -webkit-animation-duration: 6s;
+     -moz-animation-duration: 6s;
+      -ms-animation-duration: 6s;
+          animation-duration: 6s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+  -webkit-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+     -moz-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+      -ms-transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+          transform-origin: 12.5px 15.15px 0; /* TODO FF CENTER ISSUE */
+}
+
+@keyframes am-weather-moon-star-1 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-1 {
+  -webkit-animation-name: am-weather-moon-star-1;
+     -moz-animation-name: am-weather-moon-star-1;
+      -ms-animation-name: am-weather-moon-star-1;
+          animation-name: am-weather-moon-star-1;
+  -webkit-animation-delay: 3s;
+     -moz-animation-delay: 3s;
+      -ms-animation-delay: 3s;
+          animation-delay: 3s;
+  -webkit-animation-duration: 5s;
+     -moz-animation-duration: 5s;
+      -ms-animation-duration: 5s;
+          animation-duration: 5s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+@keyframes am-weather-moon-star-2 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.am-weather-moon-star-2 {
+  -webkit-animation-name: am-weather-moon-star-2;
+     -moz-animation-name: am-weather-moon-star-2;
+      -ms-animation-name: am-weather-moon-star-2;
+          animation-name: am-weather-moon-star-2;
+  -webkit-animation-delay: 5s;
+     -moz-animation-delay: 5s;
+      -ms-animation-delay: 5s;
+          animation-delay: 5s;
+  -webkit-animation-duration: 4s;
+     -moz-animation-duration: 4s;
+      -ms-animation-duration: 4s;
+          animation-duration: 4s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: 1;
+     -moz-animation-iteration-count: 1;
+      -ms-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+}
+
+/*
+** RAIN
+*/
+@keyframes am-weather-rain {
+  0% {
+    stroke-dashoffset: 0;
+  }
+
+  100% {
+    stroke-dashoffset: -100;
+  }
+}
+
+.am-weather-rain-1 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-rain-2 {
+  -webkit-animation-name: am-weather-rain;
+     -moz-animation-name: am-weather-rain;
+      -ms-animation-name: am-weather-rain;
+          animation-name: am-weather-rain;
+  -webkit-animation-delay: 0.25s;
+     -moz-animation-delay: 0.25s;
+      -ms-animation-delay: 0.25s;
+          animation-delay: 0.25s;
+  -webkit-animation-duration: 8s;
+     -moz-animation-duration: 8s;
+      -ms-animation-duration: 8s;
+          animation-duration: 8s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+
+/*
+** SNOW
+*/
+@keyframes am-weather-snow {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(-1.2px) translateY(2px);
+       -moz-transform: translateX(-1.2px) translateY(2px);
+        -ms-transform: translateX(-1.2px) translateY(2px);
+            transform: translateX(-1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(1.4px) translateY(4px);
+       -moz-transform: translateX(1.4px) translateY(4px);
+        -ms-transform: translateX(1.4px) translateY(4px);
+            transform: translateX(1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(-1.6px) translateY(6px);
+       -moz-transform: translateX(-1.6px) translateY(6px);
+        -ms-transform: translateX(-1.6px) translateY(6px);
+            transform: translateX(-1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+@keyframes am-weather-snow-reverse {
+  0% {
+    -webkit-transform: translateX(0) translateY(0);
+       -moz-transform: translateX(0) translateY(0);
+        -ms-transform: translateX(0) translateY(0);
+            transform: translateX(0) translateY(0);
+  }
+
+  33.33% {
+    -webkit-transform: translateX(1.2px) translateY(2px);
+       -moz-transform: translateX(1.2px) translateY(2px);
+        -ms-transform: translateX(1.2px) translateY(2px);
+            transform: translateX(1.2px) translateY(2px);
+  }
+
+  66.66% {
+    -webkit-transform: translateX(-1.4px) translateY(4px);
+       -moz-transform: translateX(-1.4px) translateY(4px);
+        -ms-transform: translateX(-1.4px) translateY(4px);
+            transform: translateX(-1.4px) translateY(4px);
+    opacity: 1;
+  }
+
+  100% {
+    -webkit-transform: translateX(1.6px) translateY(6px);
+       -moz-transform: translateX(1.6px) translateY(6px);
+        -ms-transform: translateX(1.6px) translateY(6px);
+            transform: translateX(1.6px) translateY(6px);
+    opacity: 0;
+  }
+}
+
+.am-weather-snow-1 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-2 {
+  -webkit-animation-name: am-weather-snow;
+     -moz-animation-name: am-weather-snow;
+      -ms-animation-name: am-weather-snow;
+          animation-name: am-weather-snow;
+  -webkit-animation-delay: 1.2s;
+     -moz-animation-delay: 1.2s;
+      -ms-animation-delay: 1.2s;
+          animation-delay: 1.2s;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+.am-weather-snow-3 {
+  -webkit-animation-name: am-weather-snow-reverse;
+     -moz-animation-name: am-weather-snow-reverse;
+      -ms-animation-name: am-weather-snow-reverse;
+          animation-name: am-weather-snow-reverse;
+  -webkit-animation-duration: 2s;
+     -moz-animation-duration: 2s;
+      -ms-animation-duration: 2s;
+          animation-duration: 2s;
+  -webkit-animation-timing-function: linear;
+     -moz-animation-timing-function: linear;
+      -ms-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-iteration-count: infinite;
+     -moz-animation-iteration-count: infinite;
+      -ms-animation-iteration-count: infinite;
+          animation-iteration-count: infinite;
+}
+
+/*
+** EASING
+*/
+.am-weather-easing-ease-in-out {
+  -webkit-animation-timing-function: ease-in-out;
+     -moz-animation-timing-function: ease-in-out;
+      -ms-animation-timing-function: ease-in-out;
+          animation-timing-function: ease-in-out;
+}
+
+        ]]></style>
+    </defs>
+    <g id="thunder">
+        <g transform="translate(20,10)">
+            <g class="am-weather-cloud-1">
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-10,-6), scale(0.6)" />
+            </g>
+            <g>
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)" />
+            </g>
+            <g transform="translate(-9,28), scale(1.2)">
+                <polygon class="am-weather-stroke" fill="orange" stroke="white" stroke-width="1" points="14.3,-2.9 20.5,-2.9 16.4,4.3 20.3,4.3 11.5,14.6 14.9,6.9 11.1,6.9" />
+            </g>
+        </g>
+    </g>
+    <g id="day">
+        <g transform="translate(32,32)">
+            <g class="am-weather-sun am-weather-sun-shiny am-weather-easing-ease-in-out">
+                <g>
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(45)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(90)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(135)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(180)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(225)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(270)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+                <g transform="rotate(315)">
+                    <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3" />
+                </g>
+            </g>
+            <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+        </g>
+    </g>
+    <g id="night">
+        <g transform="translate(20,20)">
+            <g class="am-weather-moon-star-1">
+                <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+            </g>
+            <g class="am-weather-moon-star-2">
+                <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+            </g>
+            <g class="am-weather-moon">
+                <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+            </g>
+        </g>
+    </g>
+    <g id="cloudy-day-1">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#C6DEFF" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+    <g id="cloudy-night-1">
+        <g transform="translate(20,10)">
+            <g transform="translate(16,4), scale(0.8)">
+                <g class="am-weather-moon-star-1">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+                </g>
+                <g class="am-weather-moon-star-2">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+                </g>
+                <g class="am-weather-moon">
+                    <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+                </g>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4    c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#C6DEFF" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+    <g id="cloudy-day-2">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+    <g id="cloudy-night-2">
+        <g transform="translate(20,10)">
+            <g transform="translate(16,4), scale(0.8)">
+                <g class="am-weather-moon-star-1">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+                </g>
+                <g class="am-weather-moon-star-2">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+                </g>
+                <g class="am-weather-moon">
+                    <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+                </g>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4    c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+    <g id="cloudy-day-3">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+    <g id="cloudy-night-3">
+        <g transform="translate(20,10)">
+            <g transform="translate(16,4), scale(0.8)">
+                <g class="am-weather-moon-star-1">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10"/>
+                </g>
+                <g class="am-weather-moon-star-2">
+                    <polygon fill="orange" points="3.3,1.5 4,2.7 5.2,3.3 4,4 3.3,5.2 2.7,4 1.5,3.3 2.7,2.7" stroke="none" stroke-miterlimit="10" transform="translate(20,10)"/>
+                </g>
+                <g class="am-weather-moon">
+                    <path d="M14.5,13.2c0-3.7,2-6.9,5-8.7   c-1.5-0.9-3.2-1.3-5-1.3c-5.5,0-10,4.5-10,10s4.5,10,10,10c1.8,0,3.5-0.5,5-1.3C16.5,20.2,14.5,16.9,14.5,13.2z" fill="orange" stroke="orange" stroke-linejoin="round" stroke-width="2"/>
+                </g>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4    c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+    <g id="cloudy">
+        <g transform="translate(20,10)">
+            <g class="am-weather-cloud-1">
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#91C0F8" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-10,-8), scale(0.6)"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4     c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3     c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+    </g>
+    <g id="rainy-1">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16), scale(1.2)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.5" transform="translate(-15,-5), scale(0.85)"/>
+            </g>
+        </g>
+        <g transform="translate(34,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+    <g id="rainy-2">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(37,45), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+    <g id="rainy-3">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fifll="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(34,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+    <g id="rainy-4">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(37,45), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+    <g id="rainy-5">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(34,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(-6,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,7" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+    <g id="rainy-6">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(31,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,4" stroke-linecap="round" stroke-width="2" transform="translate(-4,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="4,4" stroke-linecap="round" stroke-width="2" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="4,4" stroke-linecap="round" stroke-width="2" transform="translate(4,0)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+    <g id="rainy-7">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g transform="translate(31,46), rotate(10)">
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="0.1,7" stroke-linecap="round" stroke-width="3" transform="translate(-5,1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-2" fill="none" stroke="#91C0F8" stroke-dasharray="0.1,7" stroke-linecap="round" stroke-width="3" transform="translate(0,-1)" x1="0" x2="0" y1="0" y2="8" />
+            <line class="am-weather-rain-1" fill="none" stroke="#91C0F8" stroke-dasharray="0.1,7" stroke-linecap="round" stroke-width="3" transform="translate(5,0)" x1="0" x2="0" y1="0" y2="8" />
+        </g>
+    </g>
+    <g id="snowy-1">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16), scale(1.2)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.5" transform="translate(-15,-5), scale(0.85)"/>
+            </g>
+        </g>
+        <g transform="translate(20,9)">
+            <g class="am-weather-snow-1">
+                <g transform="translate(7,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(16,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </g>
+    <g id="snowy-2">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+        </g>
+        <g class="am-weather-snow-1">
+            <g transform="translate(32,38)">
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+            </g>
+        </g>
+    </g>
+    <g id="snowy-3">
+        <g transform="translate(20,10)">
+            <g transform="translate(0,16)">
+                <g class="am-weather-sun">
+                    <g>
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(45)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(90)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(135)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(180)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(225)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(270)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                    <g transform="rotate(315)">
+                        <line fill="none" stroke="orange" stroke-linecap="round" stroke-width="2" transform="translate(0,9)" x1="0" x2="0" y1="0" y2="3"/>
+                    </g>
+                </g>
+                <circle cx="0" cy="0" fill="orange" r="5" stroke="orange" stroke-width="2"/>
+            </g>
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(7,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(16,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </g>
+    <g id="snowy-4">
+        <g transform="translate(20,10)">
+            <g>
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(11,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </g>
+    <g id="snowy-5">
+        <g transform="translate(20,10)">
+            <g class="snowy-6-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(7,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(16,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </g>
+    <g id="snowy-6">
+        <g transform="translate(20,10)">
+            <g class="am-weather-cloud-2">
+                <path d="M47.7,35.4c0-4.6-3.7-8.2-8.2-8.2c-1,0-1.9,0.2-2.8,0.5c-0.3-3.4-3.1-6.2-6.6-6.2c-3.7,0-6.7,3-6.7,6.7c0,0.8,0.2,1.6,0.4,2.3    c-0.3-0.1-0.7-0.1-1-0.1c-3.7,0-6.7,3-6.7,6.7c0,3.6,2.9,6.6,6.5,6.7l17.2,0C44.2,43.3,47.7,39.8,47.7,35.4z" fill="#57A0EE" stroke="white" stroke-linejoin="round" stroke-width="1.2" transform="translate(-20,-11)"/>
+            </g>
+            <g class="am-weather-snow-1">
+                <g transform="translate(3,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-2">
+                <g transform="translate(11,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+            <g class="am-weather-snow-3">
+                <g transform="translate(20,28)">
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1.2" transform="translate(0,9), rotate(0)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(45)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(90)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                    <line fill="none" stroke="#57A0EE" stroke-linecap="round" stroke-width="1" transform="translate(0,9), rotate(135)" x1="0" x2="0" y1="-2.5" y2="2.5" />
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/weather_sagittarius.svg
+++ b/www/custom_ui/floorplan/images/weather/weather_sagittarius.svg
@@ -1,0 +1,9 @@
+<svg width="21px" height="17px" viewBox="187 110 21 17" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.8.3 (29802) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Wind" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(197.611216, 118.415064) rotate(-30.000000) translate(-197.611216, -118.415064) translate(189.111216, 115.915064)" stroke-linecap="round">
+        <path d="M0.5,2.5 L13,2.5" id="Line" stroke="#000000"></path>
+        <polygon id="Triangle-1" stroke="#000000" stroke-linejoin="round" fill="#000000" points="13 5 13 1.13686838e-13 17 2.5"></polygon>
+    </g>
+</svg>

--- a/www/custom_ui/floorplan/images/weather/weather_sunset.svg
+++ b/www/custom_ui/floorplan/images/weather/weather_sunset.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="64px" height="64px" viewBox="0 0 64 64" enable-background="new 0 0 64 64" xml:space="preserve">
+<line fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" x1="0" y1="47" x2="64" y2="47"/>
+<line fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" x1="10" y1="37" x2="0" y2="37"/>
+<line fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" x1="64" y1="37" x2="54" y2="37"/>
+<line fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" x1="32" y1="15" x2="32" y2="4"/>
+<line fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" x1="14" y1="23" x2="6" y2="15"/>
+<line fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" x1="50" y1="23" x2="58" y2="15"/>
+<path fill="#000000" stroke="#000000" stroke-width="2" stroke-miterlimit="10" d="M48.159,47C49.96,44.096,51,40.669,51,37
+	c0-10.493-8.506-19-19-19s-19,8.507-19,19c0,3.668,1.04,7.094,2.841,9.998"/>
+</svg>

--- a/www/custom_ui/state-card-floorplan.html
+++ b/www/custom_ui/state-card-floorplan.html
@@ -1,0 +1,24 @@
+<link rel="import" href="floorplan/ha-floorplan.html" async>
+
+<dom-module id="state-card-floorplan">
+
+  <template>
+    <ha-floorplan hass=[[hass]] config=[[stateObj.attributes.config]]></ha-floorplan>
+  </template>
+</dom-module>
+
+<script>
+  Polymer({
+    is: 'state-card-floorplan',
+
+    properties: {
+      hass: {
+        type: Object,
+      },
+      stateObj: {
+        type: Object,
+      },
+    },
+  });
+
+</script>


### PR DESCRIPTION
- Add SVG floorplan
- Custom door animations
  - floorplan.yaml only toggles between 'open' and 'close'
  - CSS classes are set in the SVG on objects directly
    instead of specifying the ID in the CSS.
    Opening CW, CCW, 45 degree doors. etc...
  - Transform origin points are in separate classes for re-usability
- Floor toggle to keep images reasonably sized
- Add SVG weather icons